### PR TITLE
fix paths

### DIFF
--- a/dataset/circom/0xbok/circom-bigint/veridise_missing_range_checks_in_bigmod/circuits/bigint.circom
+++ b/dataset/circom/0xbok/circom-bigint/veridise_missing_range_checks_in_bigmod/circuits/bigint.circom
@@ -1,8 +1,8 @@
 pragma circom 2.0.2;
 
-include "../../../dependencies/circomlib/circuits/comparators.circom";
-include "../../../dependencies/circomlib/circuits/bitify.circom";
-include "../../../dependencies/circomlib/circuits/gates.circom";
+include "../../../../dependencies/circomlib/circuits/comparators.circom";
+include "../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../dependencies/circomlib/circuits/gates.circom";
 
 include "bigint_func.circom";
 

--- a/dataset/circom/0xbok/circom-bigint/veridise_missing_range_checks_in_bigmod/zkbugs_vars.sh
+++ b/dataset/circom/0xbok/circom-bigint/veridise_missing_range_checks_in_bigmod/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot12_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/Unirep/Unirep/veridise_missing_range_checks_on_comparison_circuits/circuits/epochKeyLite.circom
+++ b/dataset/circom/Unirep/Unirep/veridise_missing_range_checks_on_comparison_circuits/circuits/epochKeyLite.circom
@@ -1,8 +1,8 @@
 pragma circom 2.0.0;
 
-include "../../../dependencies/circomlib/circuits/bitify.circom";
-include "../../../dependencies/circomlib/circuits/comparators.circom";
-include "../../../dependencies/circomlib/circuits/poseidon.circom";
+include "../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../dependencies/circomlib/circuits/comparators.circom";
+include "../../../../dependencies/circomlib/circuits/poseidon.circom";
 
 template EpochKeyLite(EPOCH_KEY_NONCE_PER_EPOCH) {
     signal input identity_secret;

--- a/dataset/circom/Unirep/Unirep/veridise_missing_range_checks_on_comparison_circuits/zkbugs_vars.sh
+++ b/dataset/circom/Unirep/Unirep/veridise_missing_range_checks_on_comparison_circuits/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot12_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/Unirep/Unirep/veridise_underconstrained_circuit_allows_invalid_comparison/circuits/bigComparators.circom
+++ b/dataset/circom/Unirep/Unirep/veridise_underconstrained_circuit_allows_invalid_comparison/circuits/bigComparators.circom
@@ -1,8 +1,8 @@
 pragma circom 2.0.0;
 
-include "../../../dependencies/circomlib/circuits/comparators.circom";
-include "../../../dependencies/circomlib/circuits/bitify.circom";
-include "../../../dependencies/circomlib/circuits/mux1.circom";
+include "../../../../dependencies/circomlib/circuits/comparators.circom";
+include "../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../dependencies/circomlib/circuits/mux1.circom";
 include "./modulo.circom";
 
 //~~ support comparisons of numbers up to the field size

--- a/dataset/circom/Unirep/Unirep/veridise_underconstrained_circuit_allows_invalid_comparison/circuits/modulo.circom
+++ b/dataset/circom/Unirep/Unirep/veridise_underconstrained_circuit_allows_invalid_comparison/circuits/modulo.circom
@@ -1,7 +1,7 @@
 pragma circom 2.0.0;
 
-include "../../../dependencies/circomlib/circuits/bitify.circom";
-include "../../../dependencies/circomlib/circuits/comparators.circom";
+include "../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../dependencies/circomlib/circuits/comparators.circom";
 
 template Modulo() {
     signal input divisor;

--- a/dataset/circom/Unirep/Unirep/veridise_underconstrained_circuit_allows_invalid_comparison/zkbugs_vars.sh
+++ b/dataset/circom/Unirep/Unirep/veridise_underconstrained_circuit_allows_invalid_comparison/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot12_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/darkforest-eth/darkforest-v0.3/daira_hopwood_darkforest_v0_3_missing_bit_length_check/circuits/range_proof/circuit.circom
+++ b/dataset/circom/darkforest-eth/darkforest-v0.3/daira_hopwood_darkforest_v0_3_missing_bit_length_check/circuits/range_proof/circuit.circom
@@ -1,6 +1,6 @@
 pragma circom 2.0.0;
 
-include "../../../../dependencies/circomlib/circuits/comparators.circom";
+include "../../../../../dependencies/circomlib/circuits/comparators.circom";
 
 // NB: RangeProof is inclusive.
 // input: field element, whose abs is claimed to be less than max_abs_value

--- a/dataset/circom/darkforest-eth/darkforest-v0.3/daira_hopwood_darkforest_v0_3_missing_bit_length_check/zkbugs_vars.sh
+++ b/dataset/circom/darkforest-eth/darkforest-v0.3/daira_hopwood_darkforest_v0_3_missing_bit_length_check/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot12_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/iden3/circomlib/kobi_gurkan_mimc_hash_assigned_but_not_constrained/zkbugs_vars.sh
+++ b/dataset/circom/iden3/circomlib/kobi_gurkan_mimc_hash_assigned_but_not_constrained/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot12_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/iden3/circomlib/veridise_decoder_accepting_bogus_output_signal/zkbugs_vars.sh
+++ b/dataset/circom/iden3/circomlib/veridise_decoder_accepting_bogus_output_signal/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot12_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_bitElementMulAny/zkbugs_vars.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_bitElementMulAny/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot12_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_window4/zkbugs_vars.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_window4/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot12_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_windowmulfix/zkbugs_vars.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_windowmulfix/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot12_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_edwards2Montgomery/zkbugs_vars.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_edwards2Montgomery/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot12_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomery2Edwards/zkbugs_vars.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomery2Edwards/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot12_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomeryAdd/zkbugs_vars.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomeryAdd/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot12_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomeryDouble/zkbugs_vars.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomeryDouble/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot12_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/personaelabs/spartan-ecdsa/yacademy_input_signal_s_is_not_constrained_in_eff_ecdsa_circom/circuits/eff_ecdsa.circom
+++ b/dataset/circom/personaelabs/spartan-ecdsa/yacademy_input_signal_s_is_not_constrained_in_eff_ecdsa_circom/circuits/eff_ecdsa.circom
@@ -1,7 +1,7 @@
 pragma circom 2.0.0;
 
 include "./secp256k1/mul.circom";
-include "../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../dependencies/circomlib/circuits/bitify.circom";
 
 /**
  *  EfficientECDSA

--- a/dataset/circom/personaelabs/spartan-ecdsa/yacademy_input_signal_s_is_not_constrained_in_eff_ecdsa_circom/circuits/secp256k1/add.circom
+++ b/dataset/circom/personaelabs/spartan-ecdsa/yacademy_input_signal_s_is_not_constrained_in_eff_ecdsa_circom/circuits/secp256k1/add.circom
@@ -1,7 +1,7 @@
 pragma circom 2.0.0;
 
-include "../../../../dependencies/circomlib/circuits/comparators.circom";
-include "../../../../dependencies/circomlib/circuits/gates.circom";
+include "../../../../../dependencies/circomlib/circuits/comparators.circom";
+include "../../../../../dependencies/circomlib/circuits/gates.circom";
 
 /**
  *  Secp256k1AddIncomplete

--- a/dataset/circom/personaelabs/spartan-ecdsa/yacademy_input_signal_s_is_not_constrained_in_eff_ecdsa_circom/circuits/secp256k1/mul.circom
+++ b/dataset/circom/personaelabs/spartan-ecdsa/yacademy_input_signal_s_is_not_constrained_in_eff_ecdsa_circom/circuits/secp256k1/mul.circom
@@ -2,9 +2,9 @@ pragma circom 2.1.2;
 
 include "./add.circom";
 include "./double.circom";
-include "../../../../dependencies/circomlib/circuits/bitify.circom";
-include "../../../../dependencies/circomlib/circuits/comparators.circom";
-include "../../../../dependencies/circomlib/circuits/gates.circom";
+include "../../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../../dependencies/circomlib/circuits/comparators.circom";
+include "../../../../../dependencies/circomlib/circuits/gates.circom";
 
 // 
 

--- a/dataset/circom/personaelabs/spartan-ecdsa/yacademy_input_signal_s_is_not_constrained_in_eff_ecdsa_circom/zkbugs_vars.sh
+++ b/dataset/circom/personaelabs/spartan-ecdsa/yacademy_input_signal_s_is_not_constrained_in_eff_ecdsa_circom/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot14_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/personaelabs/spartan-ecdsa/yacademy_under_constrained_circuits_compromising_the_soundness_of_the_system/circuits/add.circom
+++ b/dataset/circom/personaelabs/spartan-ecdsa/yacademy_under_constrained_circuits_compromising_the_soundness_of_the_system/circuits/add.circom
@@ -1,7 +1,7 @@
 pragma circom 2.1.2;
 
-include "../../../dependencies/circomlib/circuits/comparators.circom";
-include "../../../dependencies/circomlib/circuits/gates.circom";
+include "../../../../dependencies/circomlib/circuits/comparators.circom";
+include "../../../../dependencies/circomlib/circuits/gates.circom";
 
 /**
  *  Secp256k1AddIncomplete

--- a/dataset/circom/personaelabs/spartan-ecdsa/yacademy_under_constrained_circuits_compromising_the_soundness_of_the_system/circuits/mul.circom
+++ b/dataset/circom/personaelabs/spartan-ecdsa/yacademy_under_constrained_circuits_compromising_the_soundness_of_the_system/circuits/mul.circom
@@ -2,9 +2,9 @@ pragma circom 2.1.2;
 
 include "./add.circom";
 include "./double.circom";
-include "../../../dependencies/circomlib/circuits/bitify.circom";
-include "../../../dependencies/circomlib/circuits/comparators.circom";
-include "../../../dependencies/circomlib/circuits/gates.circom";
+include "../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../dependencies/circomlib/circuits/comparators.circom";
+include "../../../../dependencies/circomlib/circuits/gates.circom";
 
 // 
 

--- a/dataset/circom/personaelabs/spartan-ecdsa/yacademy_under_constrained_circuits_compromising_the_soundness_of_the_system/zkbugs_vars.sh
+++ b/dataset/circom/personaelabs/spartan-ecdsa/yacademy_under_constrained_circuits_compromising_the_soundness_of_the_system/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot14_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/ecdh.circom
+++ b/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/ecdh.circom
@@ -1,6 +1,6 @@
 pragma circom 2.0.0;
-include "../../../../dependencies/circomlib/circuits/bitify.circom";
-include "../../../../dependencies/circomlib/circuits/escalarmulany.circom";
+include "../../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../../dependencies/circomlib/circuits/escalarmulany.circom";
 
 template Ecdh() {
     // Note: the private key needs to be hashed and pruned first

--- a/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/float.circom
+++ b/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/float.circom
@@ -1,7 +1,7 @@
 pragma circom 2.0.0;
-include "../../../../dependencies/circomlib/circuits/bitify.circom";
-include "../../../../dependencies/circomlib/circuits/comparators.circom";
-include "../../../../dependencies/circomlib/circuits/mux1.circom";
+include "../../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../../dependencies/circomlib/circuits/comparators.circom";
+include "../../../../../dependencies/circomlib/circuits/mux1.circom";
 
 template IntegerDivision(n) {
     // require max(a, b) < 2**n

--- a/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/hasherSha256.circom
+++ b/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/hasherSha256.circom
@@ -1,6 +1,6 @@
 pragma circom 2.0.0;
-include "../../../../dependencies/circomlib/circuits/sha256/sha256.circom"; 
-include "../../../../dependencies/circomlib/circuits/bitify.circom"; 
+include "../../../../../dependencies/circomlib/circuits/sha256/sha256.circom"; 
+include "../../../../../dependencies/circomlib/circuits/bitify.circom"; 
 
 template Sha256HashLeftRight() {
     signal input left;

--- a/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/messageToCommand.circom
+++ b/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/messageToCommand.circom
@@ -1,8 +1,8 @@
 pragma circom 2.0.0;
 include "./ecdh.circom";
 include "./unpackElement.circom";
-include "../../../../dependencies/circomlib/circuits/bitify.circom";
-include "../../../../dependencies/circomlib/circuits/poseidon.circom";
+include "../../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../../dependencies/circomlib/circuits/poseidon.circom";
 include "./poseidon-cipher/poseidon_cipher.circom";
 
 template MessageToCommand() {

--- a/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/messageValidator.circom
+++ b/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/messageValidator.circom
@@ -1,6 +1,6 @@
 pragma circom 2.0.0;
 include "./verifySignature.circom";
-include "../../../../dependencies/circomlib/circuits/comparators.circom";
+include "../../../../../dependencies/circomlib/circuits/comparators.circom";
 
 template MessageValidator() {
     // a) Whether the state leaf index is valid

--- a/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/poseidon-cipher/poseidon_cipher.circom
+++ b/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/poseidon-cipher/poseidon_cipher.circom
@@ -10,7 +10,7 @@ pragma circom 2.0.0;
 include "poseidon-constants-old.circom";
 // we import this for util functions like Ark, Mix, Sigma
 // include "../../../../../dependencies/circomlib/circuits/poseidon_old.circom";
-include "../../../../../dependencies/circomlib/circuits/comparators.circom";
+include "../../../../../../dependencies/circomlib/circuits/comparators.circom";
 
 // Poseidon decryption circuit
 // param length: length of the input

--- a/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/poseidon/poseidonHashT3.circom
+++ b/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/poseidon/poseidonHashT3.circom
@@ -1,5 +1,5 @@
 pragma circom 2.0.0;
-include "../../../../../dependencies/circomlib/circuits/poseidon.circom";
+include "../../../../../../dependencies/circomlib/circuits/poseidon.circom";
 
 template PoseidonHashT3() {
     var nInputs = 2;

--- a/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/poseidon/poseidonHashT4.circom
+++ b/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/poseidon/poseidonHashT4.circom
@@ -1,5 +1,5 @@
 pragma circom 2.0.0;
-include "../../../../../dependencies/circomlib/circuits/poseidon.circom";
+include "../../../../../../dependencies/circomlib/circuits/poseidon.circom";
 
 template PoseidonHashT4() {
     var nInputs = 3;

--- a/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/poseidon/poseidonHashT5.circom
+++ b/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/poseidon/poseidonHashT5.circom
@@ -1,5 +1,5 @@
 pragma circom 2.0.0;
-include "../../../../../dependencies/circomlib/circuits/poseidon.circom";
+include "../../../../../../dependencies/circomlib/circuits/poseidon.circom";
 
 template PoseidonHashT5() {
     var nInputs = 4;

--- a/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/poseidon/poseidonHashT6.circom
+++ b/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/poseidon/poseidonHashT6.circom
@@ -1,5 +1,5 @@
 pragma circom 2.0.0;
-include "../../../../../dependencies/circomlib/circuits/poseidon.circom";
+include "../../../../../../dependencies/circomlib/circuits/poseidon.circom";
 
 template PoseidonHashT6() {
     var nInputs = 5;

--- a/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/privToPubKey.circom
+++ b/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/privToPubKey.circom
@@ -1,6 +1,6 @@
 pragma circom 2.0.0;
-include "../../../../dependencies/circomlib/circuits/bitify.circom";
-include "../../../../dependencies/circomlib/circuits/escalarmulfix.circom";
+include "../../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../../dependencies/circomlib/circuits/escalarmulfix.circom";
 
 template PrivToPubKey() {
     // Needs to be hashed, and then pruned before supplying it to the circuit

--- a/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/processMessages.circom
+++ b/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/processMessages.circom
@@ -5,8 +5,8 @@ include "./messageToCommand.circom";
 include "./privToPubKey.circom";
 include "./stateLeafAndBallotTransformer.circom";
 include "./trees/incrementalQuinTree.circom";
-include "../../../../dependencies/circomlib/circuits/mux1.circom";
-include "../../../../dependencies/circomlib/circuits/comparators.circom";
+include "../../../../../dependencies/circomlib/circuits/mux1.circom";
+include "../../../../../dependencies/circomlib/circuits/comparators.circom";
 
 /*
  * Proves the correctness of processing a batch of messages.

--- a/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/stateLeafAndBallotTransformer.circom
+++ b/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/stateLeafAndBallotTransformer.circom
@@ -1,6 +1,6 @@
 pragma circom 2.0.0;
 include "./messageValidator.circom";
-include "../../../../dependencies/circomlib/circuits/mux1.circom";
+include "../../../../../dependencies/circomlib/circuits/mux1.circom";
 
 /*
  * Apply a command to a state leaf and ballot.

--- a/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/subsidy.circom
+++ b/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/subsidy.circom
@@ -1,5 +1,5 @@
 pragma circom 2.0.0;
-include "../../../../dependencies/circomlib/circuits/comparators.circom";
+include "../../../../../dependencies/circomlib/circuits/comparators.circom";
 include "./trees/incrementalQuinTree.circom";
 include "./trees/calculateTotal.circom";
 include "./trees/checkRoot.circom";

--- a/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/tallyVotes.circom
+++ b/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/tallyVotes.circom
@@ -1,5 +1,5 @@
 pragma circom 2.0.0;
-include "../../../../dependencies/circomlib/circuits/comparators.circom";
+include "../../../../../dependencies/circomlib/circuits/comparators.circom";
 include "./trees/incrementalQuinTree.circom";
 include "./trees/calculateTotal.circom";
 include "./trees/checkRoot.circom";

--- a/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/trees/incrementalMerkleTree.circom
+++ b/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/trees/incrementalMerkleTree.circom
@@ -3,7 +3,7 @@ pragma circom 2.0.0;
 // https://github.com/peppersec/tornado-mixer/blob/master/circuits/merkleTree.circom
 // https://github.com/semaphore-protocol/semaphore/blob/audited/circuits/circom/semaphore-base.circom
 
-include "../../../../../dependencies/circomlib/circuits/mux1.circom";
+include "../../../../../../dependencies/circomlib/circuits/mux1.circom";
 include "../hasherPoseidon.circom";
 
 template MerkleTreeInclusionProof(n_levels) {

--- a/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/trees/incrementalQuinTree.circom
+++ b/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/trees/incrementalQuinTree.circom
@@ -1,6 +1,6 @@
 pragma circom 2.0.0;
-include "../../../../../dependencies/circomlib/circuits/mux1.circom";
-include "../../../../../dependencies/circomlib/circuits/comparators.circom";
+include "../../../../../../dependencies/circomlib/circuits/mux1.circom";
+include "../../../../../../dependencies/circomlib/circuits/comparators.circom";
 include "../hasherPoseidon.circom";
 include "./calculateTotal.circom";
 include "./checkRoot.circom";

--- a/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/unpackElement.circom
+++ b/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/unpackElement.circom
@@ -1,5 +1,5 @@
 pragma circom 2.0.0;
-include "../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../../dependencies/circomlib/circuits/bitify.circom";
 
 /*
  * Converts a field element (253 bits) to n 50-bit output elements where n <= 5

--- a/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/verifySignature.circom
+++ b/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/circuits/lib/verifySignature.circom
@@ -1,11 +1,11 @@
 pragma circom 2.0.0;
-include "../../../../dependencies/circomlib/circuits/compconstant.circom";
-include "../../../../dependencies/circomlib/circuits/comparators.circom";
-include "../../../../dependencies/circomlib/circuits/pointbits.circom";
+include "../../../../../dependencies/circomlib/circuits/compconstant.circom";
+include "../../../../../dependencies/circomlib/circuits/comparators.circom";
+include "../../../../../dependencies/circomlib/circuits/pointbits.circom";
 include "./poseidon/poseidonHashT6.circom";
-include "../../../../dependencies/circomlib/circuits/bitify.circom";
-include "../../../../dependencies/circomlib/circuits/escalarmulany.circom";
-include "../../../../dependencies/circomlib/circuits/escalarmulfix.circom";
+include "../../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../../dependencies/circomlib/circuits/escalarmulany.circom";
+include "../../../../../dependencies/circomlib/circuits/escalarmulfix.circom";
 include "./hasherPoseidon.circom";
 
 template EdDSAPoseidonVerifier_patched() {

--- a/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/zkbugs_vars.sh
+++ b/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot16_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/reclaimprotocol/circom-chacha20/zksecurity_unsound_left_rotation/zkbugs_vars.sh
+++ b/dataset/circom/reclaimprotocol/circom-chacha20/zksecurity_unsound_left_rotation/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot12_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/semaphore-protocol/semaphore/veridise_no_zero_value_validation/circuits/semaphore.circom
+++ b/dataset/circom/semaphore-protocol/semaphore/veridise_no_zero_value_validation/circuits/semaphore.circom
@@ -1,6 +1,6 @@
 pragma circom 2.0.0;
 
-include "../../../dependencies/circomlib/circuits/poseidon.circom";
+include "../../../../dependencies/circomlib/circuits/poseidon.circom";
 include "./tree.circom";
 
 template CalculateSecret() {

--- a/dataset/circom/semaphore-protocol/semaphore/veridise_no_zero_value_validation/circuits/tree.circom
+++ b/dataset/circom/semaphore-protocol/semaphore/veridise_no_zero_value_validation/circuits/tree.circom
@@ -1,7 +1,7 @@
 pragma circom 2.0.0;
 
-include "../../../dependencies/circomlib/circuits/poseidon.circom";
-include "../../../dependencies/circomlib/circuits/mux1.circom";
+include "../../../../dependencies/circomlib/circuits/poseidon.circom";
+include "../../../../dependencies/circomlib/circuits/mux1.circom";
 
 template MerkleTreeInclusionProof(nLevels) {
     signal input leaf;

--- a/dataset/circom/semaphore-protocol/semaphore/veridise_no_zero_value_validation/zkbugs_vars.sh
+++ b/dataset/circom/semaphore-protocol/semaphore/veridise_no_zero_value_validation/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot16_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_incorrect_handling_of_point_doubling_can_allow_signature_forgery/circuits/pairing/bigint.circom
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_incorrect_handling_of_point_doubling_can_allow_signature_forgery/circuits/pairing/bigint.circom
@@ -1,8 +1,8 @@
 pragma circom 2.0.3;
 
-include "../../../../dependencies/circomlib/circuits/comparators.circom";
-include "../../../../dependencies/circomlib/circuits/bitify.circom";
-include "../../../../dependencies/circomlib/circuits/gates.circom";
+include "../../../../../dependencies/circomlib/circuits/comparators.circom";
+include "../../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../../dependencies/circomlib/circuits/gates.circom";
 
 include "bigint_func.circom";
 

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_incorrect_handling_of_point_doubling_can_allow_signature_forgery/circuits/pairing/curve.circom
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_incorrect_handling_of_point_doubling_can_allow_signature_forgery/circuits/pairing/curve.circom
@@ -1,6 +1,6 @@
 pragma circom 2.0.3;
 
-include "../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../../dependencies/circomlib/circuits/bitify.circom";
 include "fp2.circom";
 
 // in[i] = (x_i, y_i) 

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_incorrect_handling_of_point_doubling_can_allow_signature_forgery/circuits/pairing/curve_fp2.circom
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_incorrect_handling_of_point_doubling_can_allow_signature_forgery/circuits/pairing/curve_fp2.circom
@@ -1,6 +1,6 @@
 pragma circom 2.0.3;
 
-include "../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../../dependencies/circomlib/circuits/bitify.circom";
 
 include "./bigint.circom";
 include "./bigint_func.circom";

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_incorrect_handling_of_point_doubling_can_allow_signature_forgery/circuits/poseidon.circom
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_incorrect_handling_of_point_doubling_can_allow_signature_forgery/circuits/poseidon.circom
@@ -1,6 +1,6 @@
 pragma circom 2.0.3;
 
-include "../../../../dependencies/circomlib/circuits/poseidon.circom";
+include "../../../../../dependencies/circomlib/circuits/poseidon.circom";
 
 /*
  * Helper functions for computing Poseidon commitments to the sync committee's

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_incorrect_handling_of_point_doubling_can_allow_signature_forgery/zkbugs_vars.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_incorrect_handling_of_point_doubling_can_allow_signature_forgery/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot14_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_including_ill-formed_bigints_in_public_key_commitment/circuits/pairing/bigint.circom
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_including_ill-formed_bigints_in_public_key_commitment/circuits/pairing/bigint.circom
@@ -1,8 +1,8 @@
 pragma circom 2.0.3;
 
-include "../../../../dependencies/circomlib/circuits/comparators.circom";
-include "../../../../dependencies/circomlib/circuits/bitify.circom";
-include "../../../../dependencies/circomlib/circuits/gates.circom";
+include "../../../../../dependencies/circomlib/circuits/comparators.circom";
+include "../../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../../dependencies/circomlib/circuits/gates.circom";
 
 include "bigint_func.circom";
 

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_including_ill-formed_bigints_in_public_key_commitment/circuits/pairing/curve.circom
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_including_ill-formed_bigints_in_public_key_commitment/circuits/pairing/curve.circom
@@ -1,6 +1,6 @@
 pragma circom 2.0.3;
 
-include "../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../../dependencies/circomlib/circuits/bitify.circom";
 include "fp2.circom";
 
 // in[i] = (x_i, y_i) 

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_including_ill-formed_bigints_in_public_key_commitment/circuits/pairing/curve_fp2.circom
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_including_ill-formed_bigints_in_public_key_commitment/circuits/pairing/curve_fp2.circom
@@ -1,6 +1,6 @@
 pragma circom 2.0.3;
 
-include "../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../../dependencies/circomlib/circuits/bitify.circom";
 
 include "./bigint.circom";
 include "./bigint_func.circom";

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_including_ill-formed_bigints_in_public_key_commitment/circuits/pairing/extra_curve.circom
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_including_ill-formed_bigints_in_public_key_commitment/circuits/pairing/extra_curve.circom
@@ -1,6 +1,6 @@
 pragma circom 2.0.2;
 
-include ".../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../../dependencies/circomlib/circuits/bitify.circom";
 
 include "./bigint.circom";
 include "./bigint_func.circom";

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_including_ill-formed_bigints_in_public_key_commitment/zkbugs_vars.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_including_ill-formed_bigints_in_public_key_commitment/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot12_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_supplying_non-reduced_Y_values_to_G1BigIntToSignFlag/circuits/pairing/bigint.circom
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_supplying_non-reduced_Y_values_to_G1BigIntToSignFlag/circuits/pairing/bigint.circom
@@ -1,8 +1,8 @@
 pragma circom 2.0.3;
 
-include "../../../../dependencies/circomlib/circuits/comparators.circom";
-include "../../../../dependencies/circomlib/circuits/bitify.circom";
-include "../../../../dependencies/circomlib/circuits/gates.circom";
+include "../../../../../dependencies/circomlib/circuits/comparators.circom";
+include "../../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../../dependencies/circomlib/circuits/gates.circom";
 
 include "bigint_func.circom";
 

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_supplying_non-reduced_Y_values_to_G1BigIntToSignFlag/circuits/pairing/curve.circom
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_supplying_non-reduced_Y_values_to_G1BigIntToSignFlag/circuits/pairing/curve.circom
@@ -1,6 +1,6 @@
 pragma circom 2.0.3;
 
-include "../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../../dependencies/circomlib/circuits/bitify.circom";
 include "fp2.circom";
 
 // in[i] = (x_i, y_i) 

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_supplying_non-reduced_Y_values_to_G1BigIntToSignFlag/circuits/pairing/curve_fp2.circom
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_supplying_non-reduced_Y_values_to_G1BigIntToSignFlag/circuits/pairing/curve_fp2.circom
@@ -1,6 +1,6 @@
 pragma circom 2.0.3;
 
-include "../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../../dependencies/circomlib/circuits/bitify.circom";
 
 include "./bigint.circom";
 include "./bigint_func.circom";

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_supplying_non-reduced_Y_values_to_G1BigIntToSignFlag/circuits/pairing/extra_curve.circom
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_supplying_non-reduced_Y_values_to_G1BigIntToSignFlag/circuits/pairing/extra_curve.circom
@@ -1,6 +1,6 @@
 pragma circom 2.0.2;
 
-include "../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../../dependencies/circomlib/circuits/bitify.circom";
 
 include "./bigint.circom";
 include "./bigint_func.circom";

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_supplying_non-reduced_Y_values_to_G1BigIntToSignFlag/zkbugs_vars.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_supplying_non-reduced_Y_values_to_G1BigIntToSignFlag/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot12_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/succinctlabs/telepathy-circuits/veridise_arrayxor_is_under_constrained/zkbugs_vars.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/veridise_arrayxor_is_under_constrained/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot12_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/succinctlabs/telepathy-circuits/veridise_template_CoreVerifyPubkeyG1_does_not_perform_input_validation_simplified/circuits/bigint.circom
+++ b/dataset/circom/succinctlabs/telepathy-circuits/veridise_template_CoreVerifyPubkeyG1_does_not_perform_input_validation_simplified/circuits/bigint.circom
@@ -1,8 +1,8 @@
 pragma circom 2.0.3;
 
-include "../../../dependencies/circomlib/circuits/comparators.circom";
-include "../../../dependencies/circomlib/circuits/bitify.circom";
-include "../../../dependencies/circomlib/circuits/gates.circom";
+include "../../../../dependencies/circomlib/circuits/comparators.circom";
+include "../../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../dependencies/circomlib/circuits/gates.circom";
 
 include "bigint_func.circom";
 

--- a/dataset/circom/succinctlabs/telepathy-circuits/veridise_template_CoreVerifyPubkeyG1_does_not_perform_input_validation_simplified/circuits/curve.circom
+++ b/dataset/circom/succinctlabs/telepathy-circuits/veridise_template_CoreVerifyPubkeyG1_does_not_perform_input_validation_simplified/circuits/curve.circom
@@ -1,6 +1,6 @@
 pragma circom 2.0.3;
 
-include "../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../dependencies/circomlib/circuits/bitify.circom";
 include "fp2.circom";
 
 // in[i] = (x_i, y_i) 

--- a/dataset/circom/succinctlabs/telepathy-circuits/veridise_template_CoreVerifyPubkeyG1_does_not_perform_input_validation_simplified/circuits/curve_fp2.circom
+++ b/dataset/circom/succinctlabs/telepathy-circuits/veridise_template_CoreVerifyPubkeyG1_does_not_perform_input_validation_simplified/circuits/curve_fp2.circom
@@ -1,6 +1,6 @@
 pragma circom 2.0.3;
 
-include "../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../dependencies/circomlib/circuits/bitify.circom";
 
 include "./bigint.circom";
 include "./bigint_func.circom";

--- a/dataset/circom/succinctlabs/telepathy-circuits/veridise_template_CoreVerifyPubkeyG1_does_not_perform_input_validation_simplified/circuits/extra_curve.circom
+++ b/dataset/circom/succinctlabs/telepathy-circuits/veridise_template_CoreVerifyPubkeyG1_does_not_perform_input_validation_simplified/circuits/extra_curve.circom
@@ -1,6 +1,6 @@
 pragma circom 2.0.2;
 
-include "../../../dependencies/circomlib/circuits/bitify.circom";
+include "../../../../dependencies/circomlib/circuits/bitify.circom";
 
 include "./bigint.circom";
 include "./bigint_func.circom";

--- a/dataset/circom/succinctlabs/telepathy-circuits/veridise_template_CoreVerifyPubkeyG1_does_not_perform_input_validation_simplified/zkbugs_vars.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/veridise_template_CoreVerifyPubkeyG1_does_not_perform_input_validation_simplified/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot16_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/succinctlabs/telepathy-circuits/veridise_zero_padding_for_sha256_in_ExpandMessageXMD_is_vulnerable_to_an_overflow/zkbugs_vars.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/veridise_zero_padding_for_sha256_in_ExpandMessageXMD_is_vulnerable_to_an_overflow/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot12_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"

--- a/dataset/circom/zkopru-network/zkopru/leastauthority_previously_correct_ownership_proof_disabled_via_code_changes/circuits/ownership_proof.circom
+++ b/dataset/circom/zkopru-network/zkopru/leastauthority_previously_correct_ownership_proof_disabled_via_code_changes/circuits/ownership_proof.circom
@@ -1,6 +1,6 @@
 pragma circom 2.0.0;
 
-include "../../../dependencies/circomlib/circuits/eddsaposeidon.circom";
+include "../../../../dependencies/circomlib/circuits/eddsaposeidon.circom";
 
 template OwnershipProof() {
     // Signal definitions

--- a/dataset/circom/zkopru-network/zkopru/leastauthority_previously_correct_ownership_proof_disabled_via_code_changes/zkbugs_vars.sh
+++ b/dataset/circom/zkopru-network/zkopru/leastauthority_previously_correct_ownership_proof_disabled_via_code_changes/zkbugs_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_PATH=$(realpath "$0")
-ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
 PTAU_TARGET=bn128_pot16_0001.ptau
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"


### PR DESCRIPTION
The `ROOT_PATH` definition in `zkbugs_vars.sh` was one directory too shallow. Updated it from: 
```
ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")
``` 

to:

```
ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
```

Similarly, the circuit files referenced dependencies with an incorrect relative path.
For example, updated includes like:

```
include "../../../dependencies/*
```

to:

```
include "../../../../dependencies/*
```

This ensures both the environment variables and circuit dependency references resolve correctly.
