### PR TITLE
Add worm-privacy/proof-of-burn Spend missing range-check bug

### DIFF
--- a/dataset/circom/Unirep/Unirep/veridise_missing_range_checks_on_comparison_circuits/zkbugs_config.json
+++ b/dataset/circom/Unirep/Unirep/veridise_missing_range_checks_on_comparison_circuits/zkbugs_config.json
@@ -38,7 +38,8 @@
         "Proposed Mitigation": "Implement range check so that attacker can't exploit overflow in `LessThan`.",
         "Similar Bugs": [
             "darkforest-eth/darkforest-v0.3/daira_hopwood_darkforest_v0_3_missing_bit_length_check",
-            "selfxyz/self/zksecurity_the_registration_and_disclosure_circuits_lack_range_checks_for_the_input_indices"
+            "selfxyz/self/zksecurity_the_registration_and_disclosure_circuits_lack_range_checks_for_the_input_indices",
+            "worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check"
         ],
         "Executed": true,
         "Compiled Direct": true,

--- a/dataset/circom/darkforest-eth/darkforest-v0.3/daira_hopwood_darkforest_v0_3_missing_bit_length_check/zkbugs_config.json
+++ b/dataset/circom/darkforest-eth/darkforest-v0.3/daira_hopwood_darkforest_v0_3_missing_bit_length_check/zkbugs_config.json
@@ -38,7 +38,8 @@
         "Proposed Mitigation": "Add constraints to check the range of `in` and `max_abs_value`. This can be done using the `Num2Bits` template.",
         "Similar Bugs": [
             "Unirep/Unirep/veridise_missing_range_checks_on_comparison_circuits",
-            "selfxyz/self/zksecurity_the_registration_and_disclosure_circuits_lack_range_checks_for_the_input_indices"
+            "selfxyz/self/zksecurity_the_registration_and_disclosure_circuits_lack_range_checks_for_the_input_indices",
+            "worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check"
         ],
         "Executed": true,
         "Compiled Direct": true,

--- a/dataset/circom/selfxyz/self/zksecurity_the_registration_and_disclosure_circuits_lack_range_checks_for_the_input_indices/zkbugs_config.json
+++ b/dataset/circom/selfxyz/self/zksecurity_the_registration_and_disclosure_circuits_lack_range_checks_for_the_input_indices/zkbugs_config.json
@@ -43,7 +43,8 @@
         ],
         "Similar Bugs": [
             "Unirep/Unirep/veridise_missing_range_checks_on_comparison_circuits",
-            "darkforest-eth/darkforest-v0.3/daira_hopwood_darkforest_v0_3_missing_bit_length_check"
+            "darkforest-eth/darkforest-v0.3/daira_hopwood_darkforest_v0_3_missing_bit_length_check",
+            "worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check"
         ]
     }
 }

--- a/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/README.md
+++ b/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/README.md
@@ -1,0 +1,61 @@
+# Spend missing range checks on GreaterEqThan inputs
+
+* Id: worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check
+* Project: https://github.com/worm-privacy/proof-of-burn
+* Commit: 0802485d24fed18fe063e51bcbb0bc830585855f
+* Fix Commit: 90772b1c9fe73d1452e047fe49ca4fdc346472a0
+* DSL: Circom
+* Vulnerability: Under-Constrained
+* Impact: Soundness
+* Root Cause: Missing Input Constraints
+* Reproduced: False
+* Codebase: dataset/codebases/circom/worm-privacy/proof-of-burn/0802485d24fed18fe063e51bcbb0bc830585855f
+* Original Entrypoint: circuits/spend.circom
+* Direct Entrypoint: circuit.circom
+* Location
+  - Path: circuits/spend.circom
+  - Function: Spend
+  - Line: 42-45
+* Source: GitHub Issue
+  - Source Link: https://github.com/worm-privacy/proof-of-burn/issues/1
+  - Bug ID: #1: Spend missing range checks on GreaterEqThan inputs
+* Input
+  - Original: input.json
+  - Direct: direct_input.json
+* Commands
+  - Setup Environment: `./zkbugs_setup.sh`
+  - Compile: `./zkbugs_compile.sh`
+  - Compile and Preprocess: `./zkbugs_compile_setup.sh`
+  - Positive Test: `./zkbugs_positive_test.sh`
+  - Clean: `./zkbugs_clean.sh`
+
+## Running
+
+Scripts support two modes controlled by the `ZKBUGS_MODE` environment variable:
+
+- **`original`** (default): compiles the project's main circuit from the full codebase.
+- **`direct`**: compiles an isolated wrapper (`circuit.circom`) that only instantiates the vulnerable template.
+
+```bash
+# Setup (run once)
+./zkbugs_setup.sh
+
+# Compile only (no zkey ceremony)
+./zkbugs_compile.sh                        # original mode
+ZKBUGS_MODE=direct ./zkbugs_compile.sh     # direct mode
+
+# Full setup with zkey ceremony + positive test (direct mode)
+ZKBUGS_MODE=direct ./zkbugs_compile_setup.sh
+ZKBUGS_MODE=direct ./zkbugs_positive_test.sh
+
+# Clean build artifacts
+./zkbugs_clean.sh
+```
+
+## Short Description of the Vulnerability
+
+In `Spend()`, the balance check uses `GreaterEqThan(252)` on `balance` and `withdrawnBalance` without first constraining either input to fit in 252 bits. `GreaterEqThan(N)` assumes both inputs are < 2^N and is known to return incorrect results when this assumption is violated (see circomlib's `comparator-overflow` advisory). Because `balance` and `withdrawnBalance` are arbitrary BN254 field elements, a prover can choose `withdrawnBalance` close to the field prime — e.g., `withdrawnBalance = 21888242871839275222246405745257275088548364400416034343698204186575808495579` with `balance = 0` — so that `sufficientBalanceChecker.out === 1` holds even though the intended unsigned comparison `balance >= withdrawnBalance` does not. The remaining `Hasher()` chain (`coinHasher`, `remainingCoinHasher`) still commits, letting a malicious prover create a valid `Spend` proof for an invalid withdrawal where `balance < withdrawnBalance`. The bug was surfaced by zkFuzz (https://github.com/Koukyosyumei/zkFuzz).
+
+## Proposed Mitigation
+
+Range-check both inputs to `GreaterEqThan` to be less than 2^maxAmountBits before the comparison. The fix commit (90772b1c) replaces `GreaterEqThan(252)` with `AssertGreaterEqThan(maxAmountBits)` (introduced in `circuits/utils/assert.circom`) and parameterizes `Spend(maxAmountBits)`, instantiating it as `Spend(200)` so `balance` and `withdrawnBalance` are constrained to 200-bit values — far below the 252-bit overflow boundary.

--- a/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/circuit.circom
+++ b/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/circuit.circom
@@ -1,0 +1,37 @@
+pragma circom 2.2.2;
+
+include "circuits/comparators.circom";
+include "circuits/mimcsponge.circom";
+
+// Faithful reproduction of the vulnerable `Spend()` template from
+// worm-privacy/proof-of-burn @ 0802485d24. The project's own
+// `circuits/spend.circom` pulls in unused Keccak/RLP helpers whose files
+// were removed, so we redefine Spend here using circomlib directly.
+template Spend() {
+    signal input balance;
+    signal input salt;
+    signal output coin;
+
+    component coinHasher = MiMCSponge(2, 220, 1);
+    coinHasher.ins[0] <== balance;
+    coinHasher.ins[1] <== salt;
+    coinHasher.k <== 0;
+    coin <== coinHasher.outs[0];
+
+    signal input withdrawnBalance;
+    signal input remainingCoinSalt;
+    signal output remainingCoin;
+
+    component sufficientBalanceChecker = GreaterEqThan(252);
+    sufficientBalanceChecker.in[0] <== balance;
+    sufficientBalanceChecker.in[1] <== withdrawnBalance;
+    sufficientBalanceChecker.out === 1;
+
+    component remainingCoinHasher = MiMCSponge(2, 220, 1);
+    remainingCoinHasher.ins[0] <== balance - withdrawnBalance;
+    remainingCoinHasher.ins[1] <== remainingCoinSalt;
+    remainingCoinHasher.k <== 0;
+    remainingCoin <== remainingCoinHasher.outs[0];
+}
+
+component main {public [withdrawnBalance]} = Spend();

--- a/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/direct_input.json
+++ b/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/direct_input.json
@@ -1,0 +1,6 @@
+{
+    "balance": "100",
+    "salt": "12345",
+    "withdrawnBalance": "50",
+    "remainingCoinSalt": "54321"
+}

--- a/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/input.json
+++ b/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/input.json
@@ -1,0 +1,6 @@
+{
+    "balance": "100",
+    "salt": "12345",
+    "withdrawnBalance": "50",
+    "remainingCoinSalt": "54321"
+}

--- a/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/zkbugs_clean.sh
+++ b/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/zkbugs_clean.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+# Clean all possible build artifacts
+rm -rf *.sym *_0001.zkey *.r1cs *_0000.zkey *_js \
+    final.ptau proof.json verification_key.json public.json

--- a/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/zkbugs_compile.sh
+++ b/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/zkbugs_compile.sh
@@ -9,7 +9,7 @@ if ! command -v circom &> /dev/null; then
 fi
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/zkbugs_compile.sh
+++ b/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/zkbugs_compile.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+source zkbugs_vars.sh
+
+if ! command -v circom &> /dev/null; then
+    echo "circom is not installed."
+    echo "Please install it using the script: $ROOT_PATH/scripts/install_circom.sh"
+    exit 1
+fi
+
+echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
+circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+
+echo "Compilation successful."
+echo "  R1CS:  $R1CS"
+echo "  WASM:  $CIRCUITWASM"
+echo "  SYM:   $TARGET.sym"

--- a/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/zkbugs_compile_setup.sh
+++ b/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/zkbugs_compile_setup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+source zkbugs_vars.sh
+
+MISSING_TOOLS=()
+if ! command -v circom &> /dev/null; then MISSING_TOOLS+=("circom"); fi
+if ! command -v snarkjs &> /dev/null; then MISSING_TOOLS+=("snarkjs"); fi
+if [ ! -f "$PTAU_FILE" ]; then MISSING_TOOLS+=("PTAU file"); fi
+
+if [ ${#MISSING_TOOLS[@]} -ne 0 ]; then
+    echo "The following are missing: ${MISSING_TOOLS[*]}"
+    echo "Please ensure they are installed and available."
+    exit 1
+else
+    echo "circom, snarkjs, and the PTAU file are already installed."
+fi
+
+echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
+circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+
+echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
+snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v
+snarkjs groth16 setup $R1CS ${PTAU_FINAL} ${ZKEY_INIT}
+echo "zkbugs" | snarkjs zkey contribute ${ZKEY_INIT} ${ZKEY_FINAL} --name="1st Contributor Name" -v
+snarkjs zkey export verificationkey ${ZKEY_FINAL} $VKEY

--- a/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/zkbugs_compile_setup.sh
+++ b/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/zkbugs_compile_setup.sh
@@ -16,7 +16,7 @@ else
 fi
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/zkbugs_config.json
+++ b/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/zkbugs_config.json
@@ -1,0 +1,51 @@
+{
+    "Spend missing range checks on GreaterEqThan inputs": {
+        "Id": "worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check",
+        "Path": "dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check",
+        "Project": "https://github.com/worm-privacy/proof-of-burn",
+        "Commit": "0802485d24fed18fe063e51bcbb0bc830585855f",
+        "Fix Commit": "90772b1c9fe73d1452e047fe49ca4fdc346472a0",
+        "DSL": "Circom",
+        "Vulnerability": "Under-Constrained",
+        "Impact": "Soundness",
+        "Root Cause": "Missing Input Constraints",
+        "Reproduced": false,
+        "Codebase": "dataset/codebases/circom/worm-privacy/proof-of-burn/0802485d24fed18fe063e51bcbb0bc830585855f",
+        "Direct Entrypoint": "circuit.circom",
+        "Location": {
+            "Path": "circuits/spend.circom",
+            "Function": "Spend",
+            "Line": "42-45"
+        },
+        "Source": {
+            "GitHub Issue": {
+                "Source Link": "https://github.com/worm-privacy/proof-of-burn/issues/1",
+                "Bug ID": "#1: Spend missing range checks on GreaterEqThan inputs"
+            }
+        },
+        "Input": {
+            "Original": "input.json",
+            "Direct": "direct_input.json"
+        },
+        "Commands": {
+            "Setup Environment": "./zkbugs_setup.sh",
+            "Compile": "./zkbugs_compile.sh",
+            "Compile and Preprocess": "./zkbugs_compile_setup.sh",
+            "Positive Test": "./zkbugs_positive_test.sh",
+            "Clean": "./zkbugs_clean.sh"
+        },
+        "Short Description of the Vulnerability": "In `Spend()`, the balance check uses `GreaterEqThan(252)` on `balance` and `withdrawnBalance` without first constraining either input to fit in 252 bits. `GreaterEqThan(N)` assumes both inputs are < 2^N and is known to return incorrect results when this assumption is violated (see circomlib's `comparator-overflow` advisory). Because `balance` and `withdrawnBalance` are arbitrary BN254 field elements, a prover can choose `withdrawnBalance` close to the field prime — e.g., `withdrawnBalance = 21888242871839275222246405745257275088548364400416034343698204186575808495579` with `balance = 0` — so that `sufficientBalanceChecker.out === 1` holds even though the intended unsigned comparison `balance >= withdrawnBalance` does not. The remaining `Hasher()` chain (`coinHasher`, `remainingCoinHasher`) still commits, letting a malicious prover create a valid `Spend` proof for an invalid withdrawal where `balance < withdrawnBalance`. The bug was surfaced by zkFuzz (https://github.com/Koukyosyumei/zkFuzz).",
+        "Proposed Mitigation": "Range-check both inputs to `GreaterEqThan` to be less than 2^maxAmountBits before the comparison. The fix commit (90772b1c) replaces `GreaterEqThan(252)` with `AssertGreaterEqThan(maxAmountBits)` (introduced in `circuits/utils/assert.circom`) and parameterizes `Spend(maxAmountBits)`, instantiating it as `Spend(200)` so `balance` and `withdrawnBalance` are constrained to 200-bit values — far below the 252-bit overflow boundary.",
+        "Executed": true,
+        "Compiled Direct": true,
+        "Compiled Original": true,
+        "Original Entrypoint": [
+            "circuits/spend.circom"
+        ],
+        "Similar Bugs": [
+            "Unirep/Unirep/veridise_missing_range_checks_on_comparison_circuits",
+            "darkforest-eth/darkforest-v0.3/daira_hopwood_darkforest_v0_3_missing_bit_length_check",
+            "selfxyz/self/zksecurity_the_registration_and_disclosure_circuits_lack_range_checks_for_the_input_indices"
+        ]
+    }
+}

--- a/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/zkbugs_positive_test.sh
+++ b/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/zkbugs_positive_test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+source zkbugs_vars.sh
+
+echo "Computing witness"
+node $CIRCUITJS/generate_witness.js $CIRCUITWASM $INPUTJSON $WTNS
+
+echo "Producing proof"
+snarkjs groth16 prove $ZKEY_FINAL $WTNS proof.json public.json
+
+echo "Verifying proof"
+snarkjs groth16 verify $VKEY public.json proof.json

--- a/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/zkbugs_setup.sh
+++ b/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/zkbugs_setup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+source zkbugs_vars.sh
+
+echo "Root path: $ROOT_PATH"
+
+MISSING_TOOLS=()
+if ! command -v circom &> /dev/null; then MISSING_TOOLS+=("circom"); fi
+if ! command -v snarkjs &> /dev/null; then MISSING_TOOLS+=("snarkjs"); fi
+
+if [ ${#MISSING_TOOLS[@]} -ne 0 ]; then
+    echo "The following tools are missing: ${MISSING_TOOLS[*]}"
+    echo "Please install them using the script: $ROOT_PATH/scripts/install_circom.sh"
+    exit 1
+else
+    echo "circom and snarkjs are already installed."
+fi
+
+if [ -f "$PTAU_FILE" ]; then
+    echo "The PTAU file exists at: $PTAU_FILE"
+else
+    echo "The PTAU file does not exist: $PTAU_FILE"
+    exit 1
+fi
+
+# Symlink circomlib into the codebase's parent node_modules
+CODEBASE_PARENT=$(dirname "$CODEBASE_PATH")
+CIRCOMLIB_NODE_MODULES="$CODEBASE_PARENT/node_modules/circomlib/circuits"
+if [ ! -L "$CIRCOMLIB_NODE_MODULES" ]; then
+    mkdir -p "$(dirname "$CIRCOMLIB_NODE_MODULES")"
+    ln -s "$CIRCOMLIB_PATH/circuits" "$CIRCOMLIB_NODE_MODULES"
+    echo "Symlinked circomlib into $CODEBASE_PARENT/node_modules/"
+else
+    echo "circomlib symlink already exists."
+fi
+
+echo "Setup is completed."

--- a/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/zkbugs_vars.sh
+++ b/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/zkbugs_vars.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+SCRIPT_PATH=$(realpath "$0")
+BUG_DIR=$(dirname "$SCRIPT_PATH")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
+CODEBASE_PATH="$ROOT_PATH/dataset/codebases/circom/worm-privacy/proof-of-burn/0802485d24fed18fe063e51bcbb0bc830585855f"
+CIRCOMLIB_PATH="$ROOT_PATH/dataset/circom/dependencies/circomlib"
+VKEY=verification_key.json
+
+# Entrypoints: "original" uses the project's main circuits, "direct" uses the isolated wrapper.
+# The project's `circuits/spend.circom` is compiled directly via `component main = Spend()`
+# at the bottom of that file — download_sources.sh applies two compat fixes first
+# (symlinks circomlib into `circuits/circomlib/` and strips two dead `include` lines
+# for files deleted earlier in history).
+ZKBUGS_MODE=${ZKBUGS_MODE:-original}
+CIRCOM_CIRCUIT_DIRECT="$BUG_DIR/circuit.circom"
+CIRCOM_CIRCUIT_ORIGINAL="$CODEBASE_PATH/circuits/spend.circom"
+
+if [ "$ZKBUGS_MODE" = "direct" ]; then
+    CIRCOM_CIRCUIT="$CIRCOM_CIRCUIT_DIRECT"
+    PTAU_TARGET=bn128_pot14_0001.ptau
+    INPUTJSON=direct_input.json
+else
+    CIRCOM_CIRCUIT="$CIRCOM_CIRCUIT_ORIGINAL"
+    PTAU_TARGET=bn128_pot14_0001.ptau
+    INPUTJSON=input.json
+fi
+
+PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
+PTAU_FINAL="final.ptau"
+
+TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
+R1CS="$TARGET.r1cs"
+ZKEY_INIT=${TARGET}_0000.zkey
+ZKEY_FINAL=${TARGET}_0001.zkey
+CIRCUITJS=${TARGET}_js
+CIRCUITWASM=${CIRCUITJS}/${TARGET}.wasm
+WTNS=$CIRCUITJS/witness.wtns

--- a/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/zkbugs_vars.sh
+++ b/dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/zkbugs_vars.sh
@@ -28,6 +28,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"
 ZKEY_INIT=${TARGET}_0000.zkey

--- a/scripts/download_sources.sh
+++ b/scripts/download_sources.sh
@@ -473,6 +473,24 @@ CIRCEOF
     echo "  Generated semaphore entrypoint"
 fi
 
+# Fix worm-privacy/proof-of-burn: populate submodule circomlib, strip dead includes
+CB="$CODEBASES_DIR/worm-privacy/proof-of-burn/0802485d24fed18fe063e51bcbb0bc830585855f"
+if [ -d "$CB" ]; then
+    # circomlib is a git submodule at circuits/circomlib — not populated by a plain clone
+    if [ -z "$(ls -A "$CB/circuits/circomlib" 2>/dev/null)" ]; then
+        rmdir "$CB/circuits/circomlib" 2>/dev/null
+        ln -sf "$CIRCOMLIB_DEP" "$CB/circuits/circomlib"
+    fi
+    # spend.circom at this commit includes two files that were deleted earlier
+    # in history (padding.circom, hashbytes.circom) — strip them so the file compiles
+    SPEND="$CB/circuits/spend.circom"
+    if [ -f "$SPEND" ]; then
+        sedi '/include ".\/utils\/padding.circom";/d' "$SPEND"
+        sedi '/include ".\/utils\/hashbytes.circom";/d' "$SPEND"
+    fi
+    echo "  Fixed worm-privacy/proof-of-burn: circomlib symlink + stripped dead includes"
+fi
+
 # Generate selfxyz vc_and_disclose_aadhaar entrypoint (component main was commented out)
 CB="$CODEBASES_DIR/selfxyz/self/3905a30aeb19016d22c5493b8b34ade2d118da4e"
 if [ -d "$CB" ]; then


### PR DESCRIPTION
> **Depends on #66** — do not merge until #66 is merged into main. Until then the diff will also include every commit from that PR.

## Summary

- Adds `dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check/` with the bug config, direct wrapper circuit, input files, scripts, and README. Extracted from worm-privacy/proof-of-burn#1 (found by zkFuzz).
- Bug: `Spend()` uses `GreaterEqThan(252)` on `balance` and `withdrawnBalance` without range-checking either to fit in 252 bits. Because both are raw BN254 field elements, a prover can pick `withdrawnBalance` near the field prime so the comparator's internal `Num2Bits(253)` decomposition still validates while the intended unsigned comparison fails — yielding a valid Spend proof for `balance < withdrawnBalance`.
- `scripts/download_sources.sh`: adds a `worm-privacy/proof-of-burn` block that symlinks the shared circomlib dep into the project's empty `circuits/circomlib/` submodule path and strips two dead `include` lines (`padding.circom`, `hashbytes.circom`) from `circuits/spend.circom` so the original entrypoint compiles.
- Cross-links bidirectionally with three existing comparator-overflow bugs: `Unirep/Unirep/veridise_missing_range_checks_on_comparison_circuits`, `darkforest-eth/darkforest-v0.3/daira_hopwood_darkforest_v0_3_missing_bit_length_check`, `selfxyz/self/zksecurity_the_registration_and_disclosure_circuits_lack_range_checks_for_the_input_indices`.

## Verification (both modes, locally)

- `./zkbugs_compile.sh` (original) — pass
- `./zkbugs_compile_setup.sh` (original) — pass (EXPORT VERIFICATION KEY FINISHED)
- `./zkbugs_positive_test.sh` (original) — pass (OK!)
- `ZKBUGS_MODE=direct ./zkbugs_compile.sh` — pass
- `ZKBUGS_MODE=direct ./zkbugs_compile_setup.sh` — pass
- `ZKBUGS_MODE=direct ./zkbugs_positive_test.sh` — pass

## Test plan

- [ ] **Merge #66 first** so the diff on this PR is limited to the new bug + `download_sources.sh` block
- [ ] Run `./scripts/download_sources.sh` and verify the worm-privacy block logs the fix message
- [ ] `cd dataset/circom/worm-privacy/proof-of-burn/koukyosyumei_spend_missing_range_check && ./zkbugs_compile_setup.sh && ./zkbugs_positive_test.sh && ./zkbugs_clean.sh` — confirm original mode passes
- [ ] `ZKBUGS_MODE=direct ./zkbugs_compile_setup.sh && ZKBUGS_MODE=direct ./zkbugs_positive_test.sh && ./zkbugs_clean.sh` — confirm direct mode passes

---

**Depends on #82.** Merge #82 first (and, for PRs based on `automate-adding-bugs`, #66 after that) so the `CIRCOM_LINK_FLAGS` contract this PR's new bug(s) rely on is in place.
