### PR TITLE
Add 1 bug from Veridise RLN audit

### DIFF
--- a/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/README.md
+++ b/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/README.md
@@ -1,0 +1,61 @@
+# Spammers may slash themselves
+
+* Id: Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves
+* Project: https://github.com/Rate-Limiting-Nullifier/circom-rln
+* Commit: 022b690b5615d1e26874013cf216136875d8f3ab
+* Fix Commit: 
+* DSL: Circom
+* Vulnerability: Under-Constrained
+* Impact: Soundness
+* Root Cause: Circuit Design Issue
+* Reproduced: False
+* Codebase: dataset/codebases/circom/Rate-Limiting-Nullifier/circom-rln/022b690b5615d1e26874013cf216136875d8f3ab
+* Original Entrypoint: circuits/withdraw.circom
+* Direct Entrypoint: circuit.circom
+* Location
+  - Path: circuits/withdraw.circom
+  - Function: Withdraw
+  - Line: 5-11
+* Source: Audit Report
+  - Source Link: https://github.com/zksecurity/zkbugs/blob/main/reports/documents/veridise-rln.pdf
+  - Bug ID: RLN-001: Spammers may slash themselves
+* Input
+  - Original: input.json
+  - Direct: direct_input.json
+* Commands
+  - Setup Environment: `./zkbugs_setup.sh`
+  - Compile: `./zkbugs_compile.sh`
+  - Compile and Preprocess: `./zkbugs_compile_setup.sh`
+  - Positive Test: `./zkbugs_positive_test.sh`
+  - Clean: `./zkbugs_clean.sh`
+
+## Running
+
+Scripts support two modes controlled by the `ZKBUGS_MODE` environment variable:
+
+- **`original`** (default): compiles the project's main circuit from the full codebase.
+- **`direct`**: compiles an isolated wrapper (`circuit.circom`) that only instantiates the vulnerable template.
+
+```bash
+# Setup (run once)
+./zkbugs_setup.sh
+
+# Compile only (no zkey ceremony)
+./zkbugs_compile.sh                        # original mode
+ZKBUGS_MODE=direct ./zkbugs_compile.sh     # direct mode
+
+# Full setup with zkey ceremony + positive test (direct mode)
+ZKBUGS_MODE=direct ./zkbugs_compile_setup.sh
+ZKBUGS_MODE=direct ./zkbugs_positive_test.sh
+
+# Clean build artifacts
+./zkbugs_clean.sh
+```
+
+## Short Description of the Vulnerability
+
+The `Withdraw` template in `withdraw.circom` only proves knowledge of the pre-image of an `identityCommitment` via `signal output identityCommitment <== Poseidon(1)([identitySecret])`, with `addressHash` declared as `signal input addressHash;` and exposed as the sole public input through `component main { public [addressHash] } = Withdraw();`. Because `addressHash` participates in no constraint at the circuit level (it is only referenced by the surrounding smart contract as the slashing-reward beneficiary), a malicious registered user (Alice) who observes an incoming slash request targeting her own `identityCommitment` can construct a new `Withdraw` proof using her own `identitySecret` and her own `addressHash`, then front-run the original slasher's transaction. Because Alice knows her own `identitySecret`, she can also preemptively self-slash after sending pre-determined messages, recovering her staked economic collateral and defeating the spam-resistance guarantee. The circuit itself is satisfiable and correct as a proof-of-knowledge, but the protocol design lets the slashee perform the slashing.
+
+## Proposed Mitigation
+
+Split the stake so the slasher only receives a portion of the economic collateral (e.g., half burned or distributed to other protocol participants), or require `Withdraw` to provide proof of knowledge of two distinct `identity_secret_hash` pre-images (one proving Merkle-tree membership as the slasher, and one being the identity to slash), doubling the stake required to self-slash. The deployed RLN contract addresses this by taking a fee on slash/withdraw and by freezing withdrawals for `n` blocks to allow other users to slash first.

--- a/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/circuit.circom
+++ b/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/circuit.circom
@@ -1,0 +1,18 @@
+pragma circom 2.1.0;
+
+include "circomlib/circuits/poseidon.circom";
+
+// Isolated wrapper around the vulnerable `Withdraw` template from
+// circuits/withdraw.circom. `addressHash` is declared as a public input but
+// is never used inside any constraint — the circuit only proves knowledge of
+// the Poseidon pre-image of `identityCommitment`. Any holder of
+// `identitySecret` (including the slashee) can therefore construct a valid
+// `Withdraw` proof for an arbitrary `addressHash` and front-run the slasher.
+template Withdraw() {
+    signal input identitySecret;
+    signal input addressHash;
+
+    signal output identityCommitment <== Poseidon(1)([identitySecret]);
+}
+
+component main { public [addressHash] } = Withdraw();

--- a/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/direct_input.json
+++ b/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/direct_input.json
@@ -1,0 +1,4 @@
+{
+    "identitySecret": "12345",
+    "addressHash": "67890"
+}

--- a/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/input.json
+++ b/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/input.json
@@ -1,0 +1,4 @@
+{
+    "identitySecret": "12345",
+    "addressHash": "67890"
+}

--- a/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/zkbugs_clean.sh
+++ b/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/zkbugs_clean.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+# Clean all possible build artifacts
+rm -rf *.sym *_0001.zkey *.r1cs *_0000.zkey *_js \
+    final.ptau proof.json verification_key.json public.json

--- a/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/zkbugs_compile.sh
+++ b/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/zkbugs_compile.sh
@@ -9,7 +9,7 @@ if ! command -v circom &> /dev/null; then
 fi
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/zkbugs_compile.sh
+++ b/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/zkbugs_compile.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+source zkbugs_vars.sh
+
+if ! command -v circom &> /dev/null; then
+    echo "circom is not installed."
+    echo "Please install it using the script: $ROOT_PATH/scripts/install_circom.sh"
+    exit 1
+fi
+
+echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
+circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+
+echo "Compilation successful."
+echo "  R1CS:  $R1CS"
+echo "  WASM:  $CIRCUITWASM"
+echo "  SYM:   $TARGET.sym"

--- a/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/zkbugs_compile_setup.sh
+++ b/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/zkbugs_compile_setup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+source zkbugs_vars.sh
+
+MISSING_TOOLS=()
+if ! command -v circom &> /dev/null; then MISSING_TOOLS+=("circom"); fi
+if ! command -v snarkjs &> /dev/null; then MISSING_TOOLS+=("snarkjs"); fi
+if [ ! -f "$PTAU_FILE" ]; then MISSING_TOOLS+=("PTAU file"); fi
+
+if [ ${#MISSING_TOOLS[@]} -ne 0 ]; then
+    echo "The following are missing: ${MISSING_TOOLS[*]}"
+    echo "Please ensure they are installed and available."
+    exit 1
+else
+    echo "circom, snarkjs, and the PTAU file are already installed."
+fi
+
+echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
+circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+
+echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
+snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v
+snarkjs groth16 setup $R1CS ${PTAU_FINAL} ${ZKEY_INIT}
+echo "zkbugs" | snarkjs zkey contribute ${ZKEY_INIT} ${ZKEY_FINAL} --name="1st Contributor Name" -v
+snarkjs zkey export verificationkey ${ZKEY_FINAL} $VKEY

--- a/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/zkbugs_compile_setup.sh
+++ b/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/zkbugs_compile_setup.sh
@@ -16,7 +16,7 @@ else
 fi
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/zkbugs_config.json
+++ b/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/zkbugs_config.json
@@ -1,0 +1,46 @@
+{
+    "Spammers may slash themselves": {
+        "Id": "Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves",
+        "Path": "dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves",
+        "Project": "https://github.com/Rate-Limiting-Nullifier/circom-rln",
+        "Commit": "022b690b5615d1e26874013cf216136875d8f3ab",
+        "Fix Commit": "",
+        "DSL": "Circom",
+        "Vulnerability": "Under-Constrained",
+        "Impact": "Soundness",
+        "Root Cause": "Circuit Design Issue",
+        "Reproduced": false,
+        "Codebase": "dataset/codebases/circom/Rate-Limiting-Nullifier/circom-rln/022b690b5615d1e26874013cf216136875d8f3ab",
+        "Direct Entrypoint": "circuit.circom",
+        "Location": {
+            "Path": "circuits/withdraw.circom",
+            "Function": "Withdraw",
+            "Line": "5-11"
+        },
+        "Source": {
+            "Audit Report": {
+                "Source Link": "https://github.com/zksecurity/zkbugs/blob/main/reports/documents/veridise-rln.pdf",
+                "Bug ID": "RLN-001: Spammers may slash themselves"
+            }
+        },
+        "Input": {
+            "Original": "input.json",
+            "Direct": "direct_input.json"
+        },
+        "Commands": {
+            "Setup Environment": "./zkbugs_setup.sh",
+            "Compile": "./zkbugs_compile.sh",
+            "Compile and Preprocess": "./zkbugs_compile_setup.sh",
+            "Positive Test": "./zkbugs_positive_test.sh",
+            "Clean": "./zkbugs_clean.sh"
+        },
+        "Short Description of the Vulnerability": "The `Withdraw` template in `withdraw.circom` only proves knowledge of the pre-image of an `identityCommitment` via `signal output identityCommitment <== Poseidon(1)([identitySecret])`, with `addressHash` declared as `signal input addressHash;` and exposed as the sole public input through `component main { public [addressHash] } = Withdraw();`. Because `addressHash` participates in no constraint at the circuit level (it is only referenced by the surrounding smart contract as the slashing-reward beneficiary), a malicious registered user (Alice) who observes an incoming slash request targeting her own `identityCommitment` can construct a new `Withdraw` proof using her own `identitySecret` and her own `addressHash`, then front-run the original slasher's transaction. Because Alice knows her own `identitySecret`, she can also preemptively self-slash after sending pre-determined messages, recovering her staked economic collateral and defeating the spam-resistance guarantee. The circuit itself is satisfiable and correct as a proof-of-knowledge, but the protocol design lets the slashee perform the slashing.",
+        "Proposed Mitigation": "Split the stake so the slasher only receives a portion of the economic collateral (e.g., half burned or distributed to other protocol participants), or require `Withdraw` to provide proof of knowledge of two distinct `identity_secret_hash` pre-images (one proving Merkle-tree membership as the slasher, and one being the identity to slash), doubling the stake required to self-slash. The deployed RLN contract addresses this by taking a fee on slash/withdraw and by freezing withdrawals for `n` blocks to allow other users to slash first.",
+        "Executed": true,
+        "Compiled Direct": true,
+        "Compiled Original": true,
+        "Original Entrypoint": [
+            "circuits/withdraw.circom"
+        ]
+    }
+}

--- a/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/zkbugs_positive_test.sh
+++ b/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/zkbugs_positive_test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+source zkbugs_vars.sh
+
+echo "Computing witness"
+node $CIRCUITJS/generate_witness.js $CIRCUITWASM $INPUTJSON $WTNS
+
+echo "Producing proof"
+snarkjs groth16 prove $ZKEY_FINAL $WTNS proof.json public.json
+
+echo "Verifying proof"
+snarkjs groth16 verify $VKEY public.json proof.json

--- a/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/zkbugs_setup.sh
+++ b/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/zkbugs_setup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+source zkbugs_vars.sh
+
+echo "Root path: $ROOT_PATH"
+
+MISSING_TOOLS=()
+if ! command -v circom &> /dev/null; then MISSING_TOOLS+=("circom"); fi
+if ! command -v snarkjs &> /dev/null; then MISSING_TOOLS+=("snarkjs"); fi
+
+if [ ${#MISSING_TOOLS[@]} -ne 0 ]; then
+    echo "The following tools are missing: ${MISSING_TOOLS[*]}"
+    echo "Please install them using the script: $ROOT_PATH/scripts/install_circom.sh"
+    exit 1
+else
+    echo "circom and snarkjs are already installed."
+fi
+
+if [ -f "$PTAU_FILE" ]; then
+    echo "The PTAU file exists at: $PTAU_FILE"
+else
+    echo "The PTAU file does not exist: $PTAU_FILE"
+    exit 1
+fi
+
+# Symlink circomlib into the codebase's parent node_modules
+CODEBASE_PARENT=$(dirname "$CODEBASE_PATH")
+CIRCOMLIB_NODE_MODULES="$CODEBASE_PARENT/node_modules/circomlib/circuits"
+if [ ! -L "$CIRCOMLIB_NODE_MODULES" ]; then
+    mkdir -p "$(dirname "$CIRCOMLIB_NODE_MODULES")"
+    ln -s "$CIRCOMLIB_PATH/circuits" "$CIRCOMLIB_NODE_MODULES"
+    echo "Symlinked circomlib into $CODEBASE_PARENT/node_modules/"
+else
+    echo "circomlib symlink already exists."
+fi
+
+echo "Setup is completed."

--- a/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/zkbugs_vars.sh
+++ b/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/zkbugs_vars.sh
@@ -23,6 +23,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"
 ZKEY_INIT=${TARGET}_0000.zkey

--- a/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/zkbugs_vars.sh
+++ b/dataset/circom/Rate-Limiting-Nullifier/circom-rln/veridise_spammers_may_slash_themselves/zkbugs_vars.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+SCRIPT_PATH=$(realpath "$0")
+BUG_DIR=$(dirname "$SCRIPT_PATH")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
+CODEBASE_PATH="$ROOT_PATH/dataset/codebases/circom/Rate-Limiting-Nullifier/circom-rln/022b690b5615d1e26874013cf216136875d8f3ab"
+CIRCOMLIB_PATH="$ROOT_PATH/dataset/circom/dependencies"
+VKEY=verification_key.json
+
+ZKBUGS_MODE=${ZKBUGS_MODE:-original}
+CIRCOM_CIRCUIT_ORIGINAL="$CODEBASE_PATH/circuits/withdraw.circom"
+CIRCOM_CIRCUIT_DIRECT="$BUG_DIR/circuit.circom"
+
+if [ "$ZKBUGS_MODE" = "direct" ]; then
+    CIRCOM_CIRCUIT="$CIRCOM_CIRCUIT_DIRECT"
+    PTAU_TARGET=bn128_pot12_0001.ptau
+    INPUTJSON=direct_input.json
+else
+    CIRCOM_CIRCUIT="$CIRCOM_CIRCUIT_ORIGINAL"
+    PTAU_TARGET=bn128_pot12_0001.ptau
+    INPUTJSON=input.json
+fi
+
+PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
+PTAU_FINAL="final.ptau"
+
+TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
+R1CS="$TARGET.r1cs"
+ZKEY_INIT=${TARGET}_0000.zkey
+ZKEY_FINAL=${TARGET}_0001.zkey
+CIRCUITJS=${TARGET}_js
+CIRCUITWASM=${CIRCUITJS}/${TARGET}.wasm
+WTNS=$CIRCUITJS/witness.wtns

--- a/reports/reports.json
+++ b/reports/reports.json
@@ -782,22 +782,22 @@
     {
         "ID": "veridise-rln",
         "File": "documents/veridise-rln.pdf",
-        "Project": "https://appliedzkp.org",
-        "Commit": "",
+        "Project": "https://github.com/Rate-Limiting-Nullifier/circom-rln",
+        "Commit": "0x022b690b",
         "Date": "1/9/2023",
         "DSL": "Circom",
         "Auditor": "Veridise",
         "Type": "Audit Report",
-        "Notes": "Rate Limiting Nullifier (RLN) audit for Privacy and Scaling Exploration. 4 vulns (RLN-001 to 004) plus 5 formal-verification spec items. Severity counts and commit need to be filled in.",
-        "processed": false,
+        "Notes": "Rate Limiting Nullifier (RLN) audit for Privacy and Scaling Exploration. 4 vulns (RLN-001 to 004) plus 6 formal-verification spec items (V-RLN-SPEC-001 to 006) which are proofs and not counted as bugs.",
+        "processed": true,
         "bugs": {
             "critical": 0,
             "high": 0,
-            "medium": 0,
-            "low": 0,
-            "informational": 0
+            "medium": 1,
+            "low": 2,
+            "informational": 1
         },
-        "total_bugs_processed": 0
+        "total_bugs_processed": 1
     },
     {
         "ID": "veridise-sismo",

--- a/scripts/download_sources.sh
+++ b/scripts/download_sources.sh
@@ -206,6 +206,13 @@ do
 done
 
 for combo in \
+    "Rate-Limiting-Nullifier/circom-rln/022b690b5615d1e26874013cf216136875d8f3ab"
+do
+    CB="$CODEBASES_DIR/$combo"
+    setup_circomlib_symlink "$CB/node_modules/circomlib/circuits"
+done
+
+for combo in \
     "tangle-network/protocol-solidity/848d073bb17f0aaffc6d39f594cc59efedeaec89"
 do
     CB="$CODEBASES_DIR/$combo"


### PR DESCRIPTION
Adds 1 bug extracted from the Veridise Rate Limiting Nullifier audit (Sep 2023) to `dataset/circom/Rate-Limiting-Nullifier/circom-rln/`.

## TODO

- [ ] **Merge PR #66 (`automate-adding-bugs`) first** — this PR targets that branch.

## Summary

- **RLN-001 "Spammers may slash themselves"** (Medium) — `Withdraw` exposes `addressHash` as a public input but never binds it to any constraint, enabling the slashee to front-run with their own `addressHash` and recover collateral.
- Classification: Under-Constrained / Soundness / Circuit Design Issue
- Location: `circuits/withdraw.circom::Withdraw:L5-11`
- Verification: compile / setup / positive test all PASS (bn128_pot12)
- Skipped: RLN-002/003 (Warning), RLN-004 (Info), 6 V-RLN-SPEC items (Coq proofs, not bugs)

## Infra

- Registers `Rate-Limiting-Nullifier/circom-rln @ 022b690b` in `scripts/download_sources.sh` with circomlib symlink
- Marks `veridise-rln` entry in `reports/reports.json` as processed (1 Medium, 2 Low, 1 Info)

---

**Depends on #82.** Merge #82 first (and, for PRs based on `automate-adding-bugs`, #66 after that) so the `CIRCOM_LINK_FLAGS` contract this PR's new bug(s) rely on is in place.
