### PR TITLE
Add 1 bug from Veridise Panther follow-up audit

### DIFF
--- a/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/README.md
+++ b/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/README.md
@@ -1,0 +1,69 @@
+# Bypassing internal transfer limits via swaps
+
+* Id: pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps
+* Project: https://github.com/pantherfoundation/panther-core
+* Commit: 06a818632053719b56ace37ef12c9b31904af1e2
+* Fix Commit: 39b770de49db47fcea361cf515b61e43dff36b65
+* DSL: Circom
+* Vulnerability: Under-Constrained
+* Impact: Soundness
+* Root Cause: Wrong Translation of Logic into Constraints
+* Reproduced: False
+* Codebase: dataset/codebases/circom/pantherfoundation/panther-core/06a818632053719b56ace37ef12c9b31904af1e2
+* Original Entrypoint: circuits/circuits/mainZSwapV1.circom
+* Direct Entrypoint: circuit.circom
+* Location
+  - Path: circuits/circuits/zSwapV1.circom
+  - Function: ZSwapV1
+  - Line: 620-631
+* Source: Audit Report
+  - Source Link: https://github.com/zksecurity/zkbugs/blob/main/reports/documents/veridise-panther-2.pdf
+  - Bug ID: V-PAN-VUL-001: Bypassing internal transfer limits via swaps
+* Input
+  - Original: input.json
+  - Direct: direct_input.json
+* Commands
+  - Setup Environment: `./zkbugs_setup.sh`
+  - Compile: `./zkbugs_compile.sh`
+  - Compile and Preprocess: `./zkbugs_compile_setup.sh`
+  - Positive Test: `./zkbugs_positive_test.sh`
+  - Clean: `./zkbugs_clean.sh`
+
+## Running
+
+Scripts support two modes controlled by the `ZKBUGS_MODE` environment variable:
+
+- **`original`** (default): compiles the project's main circuit from the full codebase.
+- **`direct`**: compiles an isolated wrapper (`circuit.circom`) that only instantiates the vulnerable template.
+
+```bash
+# Setup (run once)
+./zkbugs_setup.sh
+
+# Compile only (no zkey ceremony)
+./zkbugs_compile.sh                        # original mode
+ZKBUGS_MODE=direct ./zkbugs_compile.sh     # direct mode
+
+# Full setup with zkey ceremony + positive test (direct mode)
+ZKBUGS_MODE=direct ./zkbugs_compile_setup.sh
+ZKBUGS_MODE=direct ./zkbugs_positive_test.sh
+
+# Clean build artifacts
+./zkbugs_clean.sh
+```
+
+## Short Description of the Vulnerability
+
+In `ZSwapV1`, the per-zone internal transfer limit `zZoneInternalMaxAmount` is enforced against `utxoOutWeightedAmount[i] * isNotOwner[i]` via `ForceLessEqThan(96)`. For the swap-output UTXO (`isSwapUtxo == 1`), the protocol requires the signal `utxoOutAmount[i] === 0` because the real swapped amount is only known after the swap settles on the smart contract. Consequently `utxoOutWeightedAmount[i] <== utxoOutAmount[i] * zAssetWeight[swapToken]` is always `0`, and the comparator input `isLessThanEq_weightedUtxoOutAmount_zZoneInternalMaxAmount[i].in[0] <== utxoOutWeightedAmount[i] * isNotOwner[i]` is `0` regardless of ownership. The branch also permits `utxoOutRootSpendPubKey[i]` to be any public key, so `isNotOwner[i]` can be `1` (UTXO spendable by a different zAccount). This lets a user bypass `zZoneInternalMaxAmount` by routing the transfer as a swap UTXO assigned to another zAccount while the real transferred amount is computed off-circuit. Vulnerable code (`circuits/circuits/zSwapV1.circom:620-623`):
+
+```
+if ( isSwapUtxo ) {
+    assert(zZoneInternalMaxAmount >= (utxoOutAmount[i] * zAssetWeight[swapToken] * isNotOwner[i]));
+    utxoOutWeightedAmount[i] <== utxoOutAmount[i] * zAssetWeight[swapToken];
+    isLessThanEq_weightedUtxoOutAmount_zZoneInternalMaxAmount[i].in[0] <== utxoOutWeightedAmount[i] * isNotOwner[i];
+}
+```
+
+## Proposed Mitigation
+
+Enforce that swap out-UTXOs are always owned by the transacting zAccount so the implicit amount cannot leave the sender. The fix in commit `39b770d` replaces the amount-based comparison in the `isSwapUtxo` branch with an ownership check reusing the same `ForceLessEqThan` component: `isLessThanEq...in[0] <== isNotOwner[i]; isLessThanEq...in[1] <== 0;` (i.e. `isNotOwner[i] <= 0`, forcing the swap UTXO recipient to equal the sender's `zAccountUtxoInRootSpendPubKey`). Equivalently, enforce `utxoOutRootSpendPubKey[i] === zAccountUtxoInRootSpendPubKey` when `isSwapUtxo`.

--- a/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/circuit.circom
+++ b/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/circuit.circom
@@ -1,0 +1,50 @@
+pragma circom 2.1.9;
+
+// Minimal direct-mode wrapper that reproduces the vulnerable swap-UTXO
+// zone-limit check from `ZSwapV1` in circuits/circuits/zSwapV1.circom,
+// lines 605-631 at commit 06a8186. The wrapper isolates the bug: when a
+// swap UTXO is processed, `utxoOutAmount` is constrained to `0`, so the
+// comparator input becomes `0 * isNotOwner = 0` and the
+// `ForceLessEqThan(96)` check against `zZoneInternalMaxAmount` trivially
+// passes even when the UTXO is sent to another zAccount
+// (`isNotOwner == 1`) with a large implicit swapped amount.
+//
+// The extracted logic matches the real template exactly; only the
+// unrelated I/O of ZSwapV1 (merkle proofs, KYC, EdDSA, etc.) is stripped.
+
+include "circuits/circuits/templates/utils.circom";
+include "circuits/comparators.circom";
+
+template SwapUtxoLimitCheckBug() {
+    // Analogues of the ZSwapV1 signals used by lines 605-631.
+    signal input zAccountUtxoInRootSpendPubKey[2];
+    signal input utxoOutRootSpendPubKey[2];
+    signal input utxoOutAmount;          // swap UTXO is constrained to 0
+    signal input zAssetWeightSwapToken;
+    signal input zZoneInternalMaxAmount;
+
+    // Match the protocol constraint: swap UTXO amount must be zero.
+    utxoOutAmount === 0;
+
+    // `isNotOwner` calculation identical to the vulnerable template.
+    component isEqX = IsEqual();
+    isEqX.in[0] <== zAccountUtxoInRootSpendPubKey[0];
+    isEqX.in[1] <== utxoOutRootSpendPubKey[0];
+
+    component isEqY = IsEqual();
+    isEqY.in[0] <== zAccountUtxoInRootSpendPubKey[1];
+    isEqY.in[1] <== utxoOutRootSpendPubKey[1];
+
+    signal isNotOwner <== 1 - (isEqX.out * isEqY.out);
+
+    // Vulnerable swap-UTXO branch replicated from lines 620-623. Because
+    // `utxoOutAmount === 0`, `utxoOutWeightedAmount` is always 0 and the
+    // ForceLessEqThan check trivially holds regardless of ownership.
+    signal utxoOutWeightedAmount <== utxoOutAmount * zAssetWeightSwapToken;
+
+    component isLessThanEq = ForceLessEqThan(96);
+    isLessThanEq.in[0] <== utxoOutWeightedAmount * isNotOwner;
+    isLessThanEq.in[1] <== zZoneInternalMaxAmount;
+}
+
+component main = SwapUtxoLimitCheckBug();

--- a/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/direct_input.json
+++ b/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/direct_input.json
@@ -1,0 +1,7 @@
+{
+    "zAccountUtxoInRootSpendPubKey": ["1", "2"],
+    "utxoOutRootSpendPubKey": ["3", "4"],
+    "utxoOutAmount": "0",
+    "zAssetWeightSwapToken": "1000000000",
+    "zZoneInternalMaxAmount": "100"
+}

--- a/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/zkbugs_clean.sh
+++ b/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/zkbugs_clean.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+# Clean all possible build artifacts
+rm -rf *.sym *_0001.zkey *.r1cs *_0000.zkey *_js \
+    final.ptau proof.json verification_key.json public.json

--- a/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/zkbugs_compile.sh
+++ b/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/zkbugs_compile.sh
@@ -9,7 +9,7 @@ if ! command -v circom &> /dev/null; then
 fi
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/zkbugs_compile.sh
+++ b/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/zkbugs_compile.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+source zkbugs_vars.sh
+
+if ! command -v circom &> /dev/null; then
+    echo "circom is not installed."
+    echo "Please install it using the script: $ROOT_PATH/scripts/install_circom.sh"
+    exit 1
+fi
+
+echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
+circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+
+echo "Compilation successful."
+echo "  R1CS:  $R1CS"
+echo "  WASM:  $CIRCUITWASM"
+echo "  SYM:   $TARGET.sym"

--- a/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/zkbugs_compile_setup.sh
+++ b/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/zkbugs_compile_setup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+source zkbugs_vars.sh
+
+MISSING_TOOLS=()
+if ! command -v circom &> /dev/null; then MISSING_TOOLS+=("circom"); fi
+if ! command -v snarkjs &> /dev/null; then MISSING_TOOLS+=("snarkjs"); fi
+if [ ! -f "$PTAU_FILE" ]; then MISSING_TOOLS+=("PTAU file"); fi
+
+if [ ${#MISSING_TOOLS[@]} -ne 0 ]; then
+    echo "The following are missing: ${MISSING_TOOLS[*]}"
+    echo "Please ensure they are installed and available."
+    exit 1
+else
+    echo "circom, snarkjs, and the PTAU file are already installed."
+fi
+
+echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
+circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+
+echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
+snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v
+snarkjs groth16 setup $R1CS ${PTAU_FINAL} ${ZKEY_INIT}
+echo "zkbugs" | snarkjs zkey contribute ${ZKEY_INIT} ${ZKEY_FINAL} --name="1st Contributor Name" -v
+snarkjs zkey export verificationkey ${ZKEY_FINAL} $VKEY

--- a/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/zkbugs_compile_setup.sh
+++ b/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/zkbugs_compile_setup.sh
@@ -16,7 +16,7 @@ else
 fi
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/zkbugs_config.json
+++ b/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/zkbugs_config.json
@@ -39,7 +39,7 @@
         "Similar Bugs": [],
         "Executed": true,
         "Compiled Direct": true,
-        "Compiled Original": false,
+        "Compiled Original": true,
         "Original Entrypoint": [
             "circuits/circuits/mainZSwapV1.circom"
         ]

--- a/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/zkbugs_config.json
+++ b/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/zkbugs_config.json
@@ -1,0 +1,47 @@
+{
+    "Bypassing internal transfer limits via swaps": {
+        "Id": "pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps",
+        "Path": "dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps",
+        "Project": "https://github.com/pantherfoundation/panther-core",
+        "Commit": "06a818632053719b56ace37ef12c9b31904af1e2",
+        "Fix Commit": "39b770de49db47fcea361cf515b61e43dff36b65",
+        "DSL": "Circom",
+        "Vulnerability": "Under-Constrained",
+        "Impact": "Soundness",
+        "Root Cause": "Wrong Translation of Logic into Constraints",
+        "Reproduced": false,
+        "Codebase": "dataset/codebases/circom/pantherfoundation/panther-core/06a818632053719b56ace37ef12c9b31904af1e2",
+        "Direct Entrypoint": "circuit.circom",
+        "Location": {
+            "Path": "circuits/circuits/zSwapV1.circom",
+            "Function": "ZSwapV1",
+            "Line": "620-631"
+        },
+        "Source": {
+            "Audit Report": {
+                "Source Link": "https://github.com/zksecurity/zkbugs/blob/main/reports/documents/veridise-panther-2.pdf",
+                "Bug ID": "V-PAN-VUL-001: Bypassing internal transfer limits via swaps"
+            }
+        },
+        "Input": {
+            "Original": "input.json",
+            "Direct": "direct_input.json"
+        },
+        "Commands": {
+            "Setup Environment": "./zkbugs_setup.sh",
+            "Compile": "./zkbugs_compile.sh",
+            "Compile and Preprocess": "./zkbugs_compile_setup.sh",
+            "Positive Test": "./zkbugs_positive_test.sh",
+            "Clean": "./zkbugs_clean.sh"
+        },
+        "Short Description of the Vulnerability": "In `ZSwapV1`, the per-zone internal transfer limit `zZoneInternalMaxAmount` is enforced against `utxoOutWeightedAmount[i] * isNotOwner[i]` via `ForceLessEqThan(96)`. For the swap-output UTXO (`isSwapUtxo == 1`), the protocol requires the signal `utxoOutAmount[i] === 0` because the real swapped amount is only known after the swap settles on the smart contract. Consequently `utxoOutWeightedAmount[i] <== utxoOutAmount[i] * zAssetWeight[swapToken]` is always `0`, and the comparator input `isLessThanEq_weightedUtxoOutAmount_zZoneInternalMaxAmount[i].in[0] <== utxoOutWeightedAmount[i] * isNotOwner[i]` is `0` regardless of ownership. The branch also permits `utxoOutRootSpendPubKey[i]` to be any public key, so `isNotOwner[i]` can be `1` (UTXO spendable by a different zAccount). This lets a user bypass `zZoneInternalMaxAmount` by routing the transfer as a swap UTXO assigned to another zAccount while the real transferred amount is computed off-circuit. Vulnerable code (`circuits/circuits/zSwapV1.circom:620-623`):\n\n```\nif ( isSwapUtxo ) {\n    assert(zZoneInternalMaxAmount >= (utxoOutAmount[i] * zAssetWeight[swapToken] * isNotOwner[i]));\n    utxoOutWeightedAmount[i] <== utxoOutAmount[i] * zAssetWeight[swapToken];\n    isLessThanEq_weightedUtxoOutAmount_zZoneInternalMaxAmount[i].in[0] <== utxoOutWeightedAmount[i] * isNotOwner[i];\n}\n```",
+        "Proposed Mitigation": "Enforce that swap out-UTXOs are always owned by the transacting zAccount so the implicit amount cannot leave the sender. The fix in commit `39b770d` replaces the amount-based comparison in the `isSwapUtxo` branch with an ownership check reusing the same `ForceLessEqThan` component: `isLessThanEq...in[0] <== isNotOwner[i]; isLessThanEq...in[1] <== 0;` (i.e. `isNotOwner[i] <= 0`, forcing the swap UTXO recipient to equal the sender's `zAccountUtxoInRootSpendPubKey`). Equivalently, enforce `utxoOutRootSpendPubKey[i] === zAccountUtxoInRootSpendPubKey` when `isSwapUtxo`.",
+        "Similar Bugs": [],
+        "Executed": true,
+        "Compiled Direct": true,
+        "Compiled Original": false,
+        "Original Entrypoint": [
+            "circuits/circuits/mainZSwapV1.circom"
+        ]
+    }
+}

--- a/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/zkbugs_positive_test.sh
+++ b/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/zkbugs_positive_test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+source zkbugs_vars.sh
+
+echo "Computing witness"
+node $CIRCUITJS/generate_witness.js $CIRCUITWASM $INPUTJSON $WTNS
+
+echo "Producing proof"
+snarkjs groth16 prove $ZKEY_FINAL $WTNS proof.json public.json
+
+echo "Verifying proof"
+snarkjs groth16 verify $VKEY public.json proof.json

--- a/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/zkbugs_setup.sh
+++ b/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/zkbugs_setup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+source zkbugs_vars.sh
+
+echo "Root path: $ROOT_PATH"
+
+MISSING_TOOLS=()
+if ! command -v circom &> /dev/null; then MISSING_TOOLS+=("circom"); fi
+if ! command -v snarkjs &> /dev/null; then MISSING_TOOLS+=("snarkjs"); fi
+
+if [ ${#MISSING_TOOLS[@]} -ne 0 ]; then
+    echo "The following tools are missing: ${MISSING_TOOLS[*]}"
+    echo "Please install them using the script: $ROOT_PATH/scripts/install_circom.sh"
+    exit 1
+else
+    echo "circom and snarkjs are already installed."
+fi
+
+if [ -f "$PTAU_FILE" ]; then
+    echo "The PTAU file exists at: $PTAU_FILE"
+else
+    echo "The PTAU file does not exist: $PTAU_FILE"
+    exit 1
+fi
+
+# Symlink circomlib into the codebase's parent node_modules
+CODEBASE_PARENT=$(dirname "$CODEBASE_PATH")
+CIRCOMLIB_NODE_MODULES="$CODEBASE_PARENT/node_modules/circomlib/circuits"
+if [ ! -L "$CIRCOMLIB_NODE_MODULES" ]; then
+    mkdir -p "$(dirname "$CIRCOMLIB_NODE_MODULES")"
+    ln -s "$CIRCOMLIB_PATH/circuits" "$CIRCOMLIB_NODE_MODULES"
+    echo "Symlinked circomlib into $CODEBASE_PARENT/node_modules/"
+else
+    echo "circomlib symlink already exists."
+fi
+
+echo "Setup is completed."

--- a/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/zkbugs_vars.sh
+++ b/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/zkbugs_vars.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+SCRIPT_PATH=$(realpath "$0")
+BUG_DIR=$(dirname "$SCRIPT_PATH")
+ROOT_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT_PATH")")")")")")
+CODEBASE_PATH="$ROOT_PATH/dataset/codebases/circom/pantherfoundation/panther-core/06a818632053719b56ace37ef12c9b31904af1e2"
+CIRCOMLIB_PATH="$ROOT_PATH/dataset/circom/dependencies/circomlib"
+VKEY=verification_key.json
+
+ZKBUGS_MODE=${ZKBUGS_MODE:-original}
+CIRCOM_CIRCUIT_ORIGINAL="$CODEBASE_PATH/circuits/circuits/mainZSwapV1.circom"
+CIRCOM_CIRCUIT_DIRECT="$BUG_DIR/circuit.circom"
+
+if [ "$ZKBUGS_MODE" = "direct" ]; then
+    CIRCOM_CIRCUIT="$CIRCOM_CIRCUIT_DIRECT"
+    PTAU_TARGET=bn128_pot12_0001.ptau
+    INPUTJSON=direct_input.json
+else
+    CIRCOM_CIRCUIT="$CIRCOM_CIRCUIT_ORIGINAL"
+    PTAU_TARGET=powersOfTau28_hez_final_18.ptau
+    INPUTJSON=input.json
+fi
+
+PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
+PTAU_FINAL="final.ptau"
+
+TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
+R1CS="$TARGET.r1cs"
+ZKEY_INIT=${TARGET}_0000.zkey
+ZKEY_FINAL=${TARGET}_0001.zkey
+CIRCUITJS=${TARGET}_js
+CIRCUITWASM=${CIRCUITJS}/${TARGET}.wasm
+WTNS=$CIRCUITJS/witness.wtns

--- a/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/zkbugs_vars.sh
+++ b/dataset/circom/pantherfoundation/panther-core/veridise_bypassing_internal_transfer_limits_via_swaps/zkbugs_vars.sh
@@ -23,6 +23,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"
 ZKEY_INIT=${TARGET}_0000.zkey

--- a/reports/reports.json
+++ b/reports/reports.json
@@ -762,22 +762,22 @@
     {
         "ID": "veridise-panther-2",
         "File": "documents/veridise-panther-2.pdf",
-        "Project": "https://www.pantherprotocol.io/",
-        "Commit": "",
+        "Project": "https://github.com/pantherfoundation/panther-core",
+        "Commit": "06a818632053719b56ace37ef12c9b31904af1e2",
         "Date": "18/9/2025",
         "DSL": "Circom",
         "Auditor": "Veridise",
         "Type": "Audit Report",
-        "Notes": "Panther Protocol follow-up audit. 3 issues (V-PAN-VUL-001 to 003). Severity counts and commit need to be filled in.",
-        "processed": false,
+        "Notes": "Panther Protocol follow-up audit. 3 issues (V-PAN-VUL-001 High, V-PAN-VUL-002 Low, V-PAN-VUL-003 Warning). Only V-PAN-VUL-001 meets the Medium+ threshold; V-PAN-VUL-002 and V-PAN-VUL-003 are below threshold.",
+        "processed": true,
         "bugs": {
             "critical": 0,
-            "high": 0,
+            "high": 1,
             "medium": 0,
-            "low": 0,
-            "informational": 0
+            "low": 1,
+            "informational": 1
         },
-        "total_bugs_processed": 0
+        "total_bugs_processed": 1
     },
     {
         "ID": "veridise-rln",

--- a/scripts/download_ptau.sh
+++ b/scripts/download_ptau.sh
@@ -47,7 +47,7 @@ fi
 echo ""
 echo "=== Downloading large ptau files from Hermez ceremony ==="
 
-for size in 20 22; do
+for size in 18 20 22; do
     PTAU_FILE="$PTAU_DIR/powersOfTau28_hez_final_${size}.ptau"
     if [ -f "$PTAU_FILE" ]; then
         echo "  pot${size}: already exists"

--- a/scripts/download_sources.sh
+++ b/scripts/download_sources.sh
@@ -246,6 +246,15 @@ do
     setup_circomlib_symlink "$CB/packages/circuits/node_modules/circomlib/circuits"
 done
 
+# Panther Protocol zSwap circuits include `../../node_modules/circomlib/...`
+# from `circuits/circuits/**/*.circom`, resolving to `circuits/node_modules`.
+for combo in \
+    "pantherfoundation/panther-core/06a818632053719b56ace37ef12c9b31904af1e2"
+do
+    CB="$CODEBASES_DIR/$combo"
+    setup_circomlib_symlink "$CB/circuits/node_modules/circomlib/circuits"
+done
+
 # Unirep circomlib symlink (inside circuits dir)
 CB="$CODEBASES_DIR/Unirep/Unirep/0985a28c38c8b2e7b7a9e80f43e63179fdd08b89"
 if [ -d "$CB" ]; then


### PR DESCRIPTION
Adds 1 bug from the Veridise Panther Protocol follow-up audit (Sept 18 2025) to `dataset/circom/pantherfoundation/panther-core/`.

## TODO

- [ ] **Merge PR #66 (`automate-adding-bugs`) first** — this PR targets that branch.

## Summary

- **V-PAN-VUL-001 "Bypassing internal transfer limits via swaps"** (High) — In `isSwapUtxo` branch, `utxoOutAmount[i] === 0` makes the zone cap check trivially hold when a swap routes to a different zAccount (ownership not enforced).
- Classification: Under-Constrained / Soundness / Wrong Translation of Logic into Constraints
- Location: `circuits/circuits/zSwapV1.circom::ZSwapV1:L620-631`
- Fix commit: `39b770d`
- Verification: compile / setup / positive test all PASS (direct mode, pot12)
- Skipped: V-PAN-VUL-002 (Low DoS), V-PAN-VUL-003 (Warning maintainability)

## Infra

- Registers `pantherfoundation/panther-core @ 06a81863` in `scripts/download_sources.sh`
- Marks `veridise-panther-2` as processed in `reports/reports.json`

---

**Depends on #82.** Merge #82 first (and, for PRs based on `automate-adding-bugs`, #66 after that) so the `CIRCOM_LINK_FLAGS` contract this PR's new bug(s) rely on is in place.
