### PR TITLE
circom: uniform CIRCOM_LINK_FLAGS contract + print_bug_vars helper

### DIFF
--- a/dataset/circom/0xbok/circom-bigint/veridise_missing_range_checks_in_bigmod/zkbugs_compile.sh
+++ b/dataset/circom/0xbok/circom-bigint/veridise_missing_range_checks_in_bigmod/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/0xbok/circom-bigint/veridise_missing_range_checks_in_bigmod/zkbugs_compile_setup.sh
+++ b/dataset/circom/0xbok/circom-bigint/veridise_missing_range_checks_in_bigmod/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/0xbok/circom-bigint/veridise_missing_range_checks_in_bigmod/zkbugs_vars.sh
+++ b/dataset/circom/0xbok/circom-bigint/veridise_missing_range_checks_in_bigmod/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/Unirep/Unirep/veridise_missing_range_checks_on_comparison_circuits/zkbugs_compile.sh
+++ b/dataset/circom/Unirep/Unirep/veridise_missing_range_checks_on_comparison_circuits/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/Unirep/Unirep/veridise_missing_range_checks_on_comparison_circuits/zkbugs_compile_setup.sh
+++ b/dataset/circom/Unirep/Unirep/veridise_missing_range_checks_on_comparison_circuits/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/Unirep/Unirep/veridise_missing_range_checks_on_comparison_circuits/zkbugs_vars.sh
+++ b/dataset/circom/Unirep/Unirep/veridise_missing_range_checks_on_comparison_circuits/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/Unirep/Unirep/veridise_underconstrained_circuit_allows_invalid_comparison/zkbugs_compile.sh
+++ b/dataset/circom/Unirep/Unirep/veridise_underconstrained_circuit_allows_invalid_comparison/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/Unirep/Unirep/veridise_underconstrained_circuit_allows_invalid_comparison/zkbugs_compile_setup.sh
+++ b/dataset/circom/Unirep/Unirep/veridise_underconstrained_circuit_allows_invalid_comparison/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/Unirep/Unirep/veridise_underconstrained_circuit_allows_invalid_comparison/zkbugs_vars.sh
+++ b/dataset/circom/Unirep/Unirep/veridise_underconstrained_circuit_allows_invalid_comparison/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/darkforest-eth/darkforest-v0.3/daira_hopwood_darkforest_v0_3_missing_bit_length_check/zkbugs_compile.sh
+++ b/dataset/circom/darkforest-eth/darkforest-v0.3/daira_hopwood_darkforest_v0_3_missing_bit_length_check/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/darkforest-eth/darkforest-v0.3/daira_hopwood_darkforest_v0_3_missing_bit_length_check/zkbugs_compile_setup.sh
+++ b/dataset/circom/darkforest-eth/darkforest-v0.3/daira_hopwood_darkforest_v0_3_missing_bit_length_check/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/darkforest-eth/darkforest-v0.3/daira_hopwood_darkforest_v0_3_missing_bit_length_check/zkbugs_vars.sh
+++ b/dataset/circom/darkforest-eth/darkforest-v0.3/daira_hopwood_darkforest_v0_3_missing_bit_length_check/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/iden3/circomlib/kobi_gurkan_mimc_hash_assigned_but_not_constrained/zkbugs_compile.sh
+++ b/dataset/circom/iden3/circomlib/kobi_gurkan_mimc_hash_assigned_but_not_constrained/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/iden3/circomlib/kobi_gurkan_mimc_hash_assigned_but_not_constrained/zkbugs_compile_setup.sh
+++ b/dataset/circom/iden3/circomlib/kobi_gurkan_mimc_hash_assigned_but_not_constrained/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/iden3/circomlib/kobi_gurkan_mimc_hash_assigned_but_not_constrained/zkbugs_vars.sh
+++ b/dataset/circom/iden3/circomlib/kobi_gurkan_mimc_hash_assigned_but_not_constrained/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/iden3/circomlib/veridise_decoder_accepting_bogus_output_signal/zkbugs_compile.sh
+++ b/dataset/circom/iden3/circomlib/veridise_decoder_accepting_bogus_output_signal/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/iden3/circomlib/veridise_decoder_accepting_bogus_output_signal/zkbugs_compile_setup.sh
+++ b/dataset/circom/iden3/circomlib/veridise_decoder_accepting_bogus_output_signal/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/iden3/circomlib/veridise_decoder_accepting_bogus_output_signal/zkbugs_vars.sh
+++ b/dataset/circom/iden3/circomlib/veridise_decoder_accepting_bogus_output_signal/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_bitElementMulAny/zkbugs_compile.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_bitElementMulAny/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_bitElementMulAny/zkbugs_compile_setup.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_bitElementMulAny/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_bitElementMulAny/zkbugs_vars.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_bitElementMulAny/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_window4/zkbugs_compile.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_window4/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_window4/zkbugs_compile_setup.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_window4/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_window4/zkbugs_vars.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_window4/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_windowmulfix/zkbugs_compile.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_windowmulfix/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_windowmulfix/zkbugs_compile_setup.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_windowmulfix/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_windowmulfix/zkbugs_vars.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_outputs_in_windowmulfix/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_edwards2Montgomery/zkbugs_compile.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_edwards2Montgomery/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_edwards2Montgomery/zkbugs_compile_setup.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_edwards2Montgomery/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_edwards2Montgomery/zkbugs_vars.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_edwards2Montgomery/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomery2Edwards/zkbugs_compile.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomery2Edwards/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomery2Edwards/zkbugs_compile_setup.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomery2Edwards/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomery2Edwards/zkbugs_vars.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomery2Edwards/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomeryAdd/zkbugs_compile.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomeryAdd/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomeryAdd/zkbugs_compile_setup.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomeryAdd/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomeryAdd/zkbugs_vars.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomeryAdd/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomeryDouble/zkbugs_compile.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomeryDouble/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomeryDouble/zkbugs_compile_setup.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomeryDouble/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomeryDouble/zkbugs_vars.sh
+++ b/dataset/circom/iden3/circomlib/veridise_underconstrained_points_in_montgomeryDouble/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/iden3/circuits/trailofbits_unsafe_use_of_num2bits_in_multiple_circuits/zkbugs_compile.sh
+++ b/dataset/circom/iden3/circuits/trailofbits_unsafe_use_of_num2bits_in_multiple_circuits/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/iden3/circuits/trailofbits_unsafe_use_of_num2bits_in_multiple_circuits/zkbugs_compile_setup.sh
+++ b/dataset/circom/iden3/circuits/trailofbits_unsafe_use_of_num2bits_in_multiple_circuits/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/iden3/circuits/trailofbits_unsafe_use_of_num2bits_in_multiple_circuits/zkbugs_vars.sh
+++ b/dataset/circom/iden3/circuits/trailofbits_unsafe_use_of_num2bits_in_multiple_circuits/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/personaelabs/spartan-ecdsa/yacademy_Knowledge_of_any_member_signature_allow_to_generate_proof_of_membership/zkbugs_compile.sh
+++ b/dataset/circom/personaelabs/spartan-ecdsa/yacademy_Knowledge_of_any_member_signature_allow_to_generate_proof_of_membership/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/personaelabs/spartan-ecdsa/yacademy_Knowledge_of_any_member_signature_allow_to_generate_proof_of_membership/zkbugs_compile_setup.sh
+++ b/dataset/circom/personaelabs/spartan-ecdsa/yacademy_Knowledge_of_any_member_signature_allow_to_generate_proof_of_membership/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/personaelabs/spartan-ecdsa/yacademy_Knowledge_of_any_member_signature_allow_to_generate_proof_of_membership/zkbugs_vars.sh
+++ b/dataset/circom/personaelabs/spartan-ecdsa/yacademy_Knowledge_of_any_member_signature_allow_to_generate_proof_of_membership/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/personaelabs/spartan-ecdsa/yacademy_input_signal_s_is_not_constrained_in_eff_ecdsa_circom/zkbugs_compile.sh
+++ b/dataset/circom/personaelabs/spartan-ecdsa/yacademy_input_signal_s_is_not_constrained_in_eff_ecdsa_circom/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/personaelabs/spartan-ecdsa/yacademy_input_signal_s_is_not_constrained_in_eff_ecdsa_circom/zkbugs_compile_setup.sh
+++ b/dataset/circom/personaelabs/spartan-ecdsa/yacademy_input_signal_s_is_not_constrained_in_eff_ecdsa_circom/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/personaelabs/spartan-ecdsa/yacademy_input_signal_s_is_not_constrained_in_eff_ecdsa_circom/zkbugs_vars.sh
+++ b/dataset/circom/personaelabs/spartan-ecdsa/yacademy_input_signal_s_is_not_constrained_in_eff_ecdsa_circom/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/personaelabs/spartan-ecdsa/yacademy_under_constrained_circuits_compromising_the_soundness_of_the_system/zkbugs_compile.sh
+++ b/dataset/circom/personaelabs/spartan-ecdsa/yacademy_under_constrained_circuits_compromising_the_soundness_of_the_system/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/personaelabs/spartan-ecdsa/yacademy_under_constrained_circuits_compromising_the_soundness_of_the_system/zkbugs_compile_setup.sh
+++ b/dataset/circom/personaelabs/spartan-ecdsa/yacademy_under_constrained_circuits_compromising_the_soundness_of_the_system/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/personaelabs/spartan-ecdsa/yacademy_under_constrained_circuits_compromising_the_soundness_of_the_system/zkbugs_vars.sh
+++ b/dataset/circom/personaelabs/spartan-ecdsa/yacademy_under_constrained_circuits_compromising_the_soundness_of_the_system/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/zkbugs_compile.sh
+++ b/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/zkbugs_compile.sh
@@ -9,7 +9,7 @@ if ! command -v circom &> /dev/null; then
 fi
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CODEBASE_PATH/circuits/node_modules
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/zkbugs_compile_setup.sh
+++ b/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CODEBASE_PATH/circuits/node_modules
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/zkbugs_vars.sh
+++ b/dataset/circom/privacy-scaling-explorations/maci/hashcloak_data_are_not_fully_verified_during_state_update/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CODEBASE_PATH/circuits/node_modules")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/reclaimprotocol/circom-chacha20/zksecurity_Unsound_Addition_Gadget/zkbugs_compile.sh
+++ b/dataset/circom/reclaimprotocol/circom-chacha20/zksecurity_Unsound_Addition_Gadget/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/reclaimprotocol/circom-chacha20/zksecurity_Unsound_Addition_Gadget/zkbugs_compile_setup.sh
+++ b/dataset/circom/reclaimprotocol/circom-chacha20/zksecurity_Unsound_Addition_Gadget/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/reclaimprotocol/circom-chacha20/zksecurity_Unsound_Addition_Gadget/zkbugs_vars.sh
+++ b/dataset/circom/reclaimprotocol/circom-chacha20/zksecurity_Unsound_Addition_Gadget/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/reclaimprotocol/circom-chacha20/zksecurity_Unsound_XOR_gadget/zkbugs_compile.sh
+++ b/dataset/circom/reclaimprotocol/circom-chacha20/zksecurity_Unsound_XOR_gadget/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/reclaimprotocol/circom-chacha20/zksecurity_Unsound_XOR_gadget/zkbugs_compile_setup.sh
+++ b/dataset/circom/reclaimprotocol/circom-chacha20/zksecurity_Unsound_XOR_gadget/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/reclaimprotocol/circom-chacha20/zksecurity_Unsound_XOR_gadget/zkbugs_vars.sh
+++ b/dataset/circom/reclaimprotocol/circom-chacha20/zksecurity_Unsound_XOR_gadget/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/reclaimprotocol/circom-chacha20/zksecurity_unsound_left_rotation/zkbugs_compile.sh
+++ b/dataset/circom/reclaimprotocol/circom-chacha20/zksecurity_unsound_left_rotation/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/reclaimprotocol/circom-chacha20/zksecurity_unsound_left_rotation/zkbugs_compile_setup.sh
+++ b/dataset/circom/reclaimprotocol/circom-chacha20/zksecurity_unsound_left_rotation/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/reclaimprotocol/circom-chacha20/zksecurity_unsound_left_rotation/zkbugs_vars.sh
+++ b/dataset/circom/reclaimprotocol/circom-chacha20/zksecurity_unsound_left_rotation/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/selfxyz/self/zksecurity_an_attacker_can_craft_a_fake_non_inclusion_proof_for_a_given_key_due_to_an_aliasing_bug_in_the_smt_verifier/zkbugs_compile.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_an_attacker_can_craft_a_fake_non_inclusion_proof_for_a_given_key_due_to_an_aliasing_bug_in_the_smt_verifier/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH -l $CIRCOMLIB_PATH/circomlib/circuits -l $CODEBASE_PATH/circuits/node_modules
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/selfxyz/self/zksecurity_an_attacker_can_craft_a_fake_non_inclusion_proof_for_a_given_key_due_to_an_aliasing_bug_in_the_smt_verifier/zkbugs_compile_setup.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_an_attacker_can_craft_a_fake_non_inclusion_proof_for_a_given_key_due_to_an_aliasing_bug_in_the_smt_verifier/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH -l $CIRCOMLIB_PATH/circomlib/circuits -l $CODEBASE_PATH/circuits/node_modules
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/selfxyz/self/zksecurity_an_attacker_can_craft_a_fake_non_inclusion_proof_for_a_given_key_due_to_an_aliasing_bug_in_the_smt_verifier/zkbugs_vars.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_an_attacker_can_craft_a_fake_non_inclusion_proof_for_a_given_key_due_to_an_aliasing_bug_in_the_smt_verifier/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH" -l "$CIRCOMLIB_PATH/circomlib/circuits" -l "$CODEBASE_PATH/circuits/node_modules")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/selfxyz/self/zksecurity_big_integer_zero_check_is_not_sound/zkbugs_compile.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_big_integer_zero_check_is_not_sound/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH -l $CIRCOMLIB_PATH/circomlib/circuits -l $CODEBASE_PATH/circuits/node_modules
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/selfxyz/self/zksecurity_big_integer_zero_check_is_not_sound/zkbugs_compile_setup.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_big_integer_zero_check_is_not_sound/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH -l $CIRCOMLIB_PATH/circomlib/circuits -l $CODEBASE_PATH/circuits/node_modules
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/selfxyz/self/zksecurity_big_integer_zero_check_is_not_sound/zkbugs_vars.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_big_integer_zero_check_is_not_sound/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH" -l "$CIRCOMLIB_PATH/circomlib/circuits" -l "$CODEBASE_PATH/circuits/node_modules")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/selfxyz/self/zksecurity_exclusion_check_of_forbidden_countries_is_unsound_and_incomplete_due_to_incorrect_indexing/zkbugs_compile.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_exclusion_check_of_forbidden_countries_is_unsound_and_incomplete_due_to_incorrect_indexing/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH -l $CIRCOMLIB_PATH/circomlib/circuits -l $CODEBASE_PATH/circuits/node_modules
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/selfxyz/self/zksecurity_exclusion_check_of_forbidden_countries_is_unsound_and_incomplete_due_to_incorrect_indexing/zkbugs_compile_setup.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_exclusion_check_of_forbidden_countries_is_unsound_and_incomplete_due_to_incorrect_indexing/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH -l $CIRCOMLIB_PATH/circomlib/circuits -l $CODEBASE_PATH/circuits/node_modules
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/selfxyz/self/zksecurity_exclusion_check_of_forbidden_countries_is_unsound_and_incomplete_due_to_incorrect_indexing/zkbugs_vars.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_exclusion_check_of_forbidden_countries_is_unsound_and_incomplete_due_to_incorrect_indexing/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH" -l "$CIRCOMLIB_PATH/circomlib/circuits" -l "$CODEBASE_PATH/circuits/node_modules")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/selfxyz/self/zksecurity_forbidden_country_check_bypass_via_packed_byte_overflow/zkbugs_compile.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_forbidden_country_check_bypass_via_packed_byte_overflow/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH -l $CIRCOMLIB_PATH/circomlib/circuits -l $CODEBASE_PATH/circuits/node_modules
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/selfxyz/self/zksecurity_forbidden_country_check_bypass_via_packed_byte_overflow/zkbugs_compile_setup.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_forbidden_country_check_bypass_via_packed_byte_overflow/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH -l $CIRCOMLIB_PATH/circomlib/circuits -l $CODEBASE_PATH/circuits/node_modules
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/selfxyz/self/zksecurity_forbidden_country_check_bypass_via_packed_byte_overflow/zkbugs_vars.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_forbidden_country_check_bypass_via_packed_byte_overflow/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH" -l "$CIRCOMLIB_PATH/circomlib/circuits" -l "$CODEBASE_PATH/circuits/node_modules")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/selfxyz/self/zksecurity_missing_boolean_constraints_in_the_merkle_tree_path_leads_to_an_attacker_being_able_to_craft_a_fake_merkle_proof_for_an_arbitrary_leaf/zkbugs_compile.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_missing_boolean_constraints_in_the_merkle_tree_path_leads_to_an_attacker_being_able_to_craft_a_fake_merkle_proof_for_an_arbitrary_leaf/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH -l $CIRCOMLIB_PATH/circomlib/circuits -l $CODEBASE_PATH/circuits/node_modules
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/selfxyz/self/zksecurity_missing_boolean_constraints_in_the_merkle_tree_path_leads_to_an_attacker_being_able_to_craft_a_fake_merkle_proof_for_an_arbitrary_leaf/zkbugs_compile_setup.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_missing_boolean_constraints_in_the_merkle_tree_path_leads_to_an_attacker_being_able_to_craft_a_fake_merkle_proof_for_an_arbitrary_leaf/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH -l $CIRCOMLIB_PATH/circomlib/circuits -l $CODEBASE_PATH/circuits/node_modules
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/selfxyz/self/zksecurity_missing_boolean_constraints_in_the_merkle_tree_path_leads_to_an_attacker_being_able_to_craft_a_fake_merkle_proof_for_an_arbitrary_leaf/zkbugs_vars.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_missing_boolean_constraints_in_the_merkle_tree_path_leads_to_an_attacker_being_able_to_craft_a_fake_merkle_proof_for_an_arbitrary_leaf/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH" -l "$CIRCOMLIB_PATH/circomlib/circuits" -l "$CODEBASE_PATH/circuits/node_modules")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/selfxyz/self/zksecurity_missing_byte_range_checks_allows_packed_data_pollution/zkbugs_compile.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_missing_byte_range_checks_allows_packed_data_pollution/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH -l $CIRCOMLIB_PATH/circomlib/circuits -l $CODEBASE_PATH/circuits/node_modules
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/selfxyz/self/zksecurity_missing_byte_range_checks_allows_packed_data_pollution/zkbugs_compile_setup.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_missing_byte_range_checks_allows_packed_data_pollution/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH -l $CIRCOMLIB_PATH/circomlib/circuits -l $CODEBASE_PATH/circuits/node_modules
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/selfxyz/self/zksecurity_missing_byte_range_checks_allows_packed_data_pollution/zkbugs_vars.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_missing_byte_range_checks_allows_packed_data_pollution/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH" -l "$CIRCOMLIB_PATH/circomlib/circuits" -l "$CODEBASE_PATH/circuits/node_modules")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/selfxyz/self/zksecurity_second_pre_image_attacks_on_packbytesandposeidon_may_be_used_to_register_arbitrary_passports_and_dsc_certificates/zkbugs_compile.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_second_pre_image_attacks_on_packbytesandposeidon_may_be_used_to_register_arbitrary_passports_and_dsc_certificates/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH -l $CIRCOMLIB_PATH/circomlib/circuits -l $CODEBASE_PATH/circuits/node_modules
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/selfxyz/self/zksecurity_second_pre_image_attacks_on_packbytesandposeidon_may_be_used_to_register_arbitrary_passports_and_dsc_certificates/zkbugs_compile_setup.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_second_pre_image_attacks_on_packbytesandposeidon_may_be_used_to_register_arbitrary_passports_and_dsc_certificates/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH -l $CIRCOMLIB_PATH/circomlib/circuits -l $CODEBASE_PATH/circuits/node_modules
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/selfxyz/self/zksecurity_second_pre_image_attacks_on_packbytesandposeidon_may_be_used_to_register_arbitrary_passports_and_dsc_certificates/zkbugs_vars.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_second_pre_image_attacks_on_packbytesandposeidon_may_be_used_to_register_arbitrary_passports_and_dsc_certificates/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH" -l "$CIRCOMLIB_PATH/circomlib/circuits" -l "$CODEBASE_PATH/circuits/node_modules")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/selfxyz/self/zksecurity_the_registration_and_disclosure_circuits_lack_range_checks_for_the_input_indices/zkbugs_compile.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_the_registration_and_disclosure_circuits_lack_range_checks_for_the_input_indices/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH -l $CIRCOMLIB_PATH/circomlib/circuits -l $CODEBASE_PATH/circuits/node_modules
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/selfxyz/self/zksecurity_the_registration_and_disclosure_circuits_lack_range_checks_for_the_input_indices/zkbugs_compile_setup.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_the_registration_and_disclosure_circuits_lack_range_checks_for_the_input_indices/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH -l $CIRCOMLIB_PATH/circomlib/circuits -l $CODEBASE_PATH/circuits/node_modules
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/selfxyz/self/zksecurity_the_registration_and_disclosure_circuits_lack_range_checks_for_the_input_indices/zkbugs_vars.sh
+++ b/dataset/circom/selfxyz/self/zksecurity_the_registration_and_disclosure_circuits_lack_range_checks_for_the_input_indices/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH" -l "$CIRCOMLIB_PATH/circomlib/circuits" -l "$CODEBASE_PATH/circuits/node_modules")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/semaphore-protocol/semaphore/veridise_no_zero_value_validation/zkbugs_compile.sh
+++ b/dataset/circom/semaphore-protocol/semaphore/veridise_no_zero_value_validation/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/semaphore-protocol/semaphore/veridise_no_zero_value_validation/zkbugs_compile_setup.sh
+++ b/dataset/circom/semaphore-protocol/semaphore/veridise_no_zero_value_validation/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/semaphore-protocol/semaphore/veridise_no_zero_value_validation/zkbugs_vars.sh
+++ b/dataset/circom/semaphore-protocol/semaphore/veridise_no_zero_value_validation/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_incorrect_handling_of_point_doubling_can_allow_signature_forgery/zkbugs_compile.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_incorrect_handling_of_point_doubling_can_allow_signature_forgery/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_incorrect_handling_of_point_doubling_can_allow_signature_forgery/zkbugs_compile_setup.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_incorrect_handling_of_point_doubling_can_allow_signature_forgery/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_incorrect_handling_of_point_doubling_can_allow_signature_forgery/zkbugs_vars.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_incorrect_handling_of_point_doubling_can_allow_signature_forgery/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_including_ill-formed_bigints_in_public_key_commitment/zkbugs_compile.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_including_ill-formed_bigints_in_public_key_commitment/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_including_ill-formed_bigints_in_public_key_commitment/zkbugs_compile_setup.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_including_ill-formed_bigints_in_public_key_commitment/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_including_ill-formed_bigints_in_public_key_commitment/zkbugs_vars.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_including_ill-formed_bigints_in_public_key_commitment/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_supplying_non-reduced_Y_values_to_G1BigIntToSignFlag/zkbugs_compile.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_supplying_non-reduced_Y_values_to_G1BigIntToSignFlag/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_supplying_non-reduced_Y_values_to_G1BigIntToSignFlag/zkbugs_compile_setup.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_supplying_non-reduced_Y_values_to_G1BigIntToSignFlag/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_supplying_non-reduced_Y_values_to_G1BigIntToSignFlag/zkbugs_vars.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/trailofbits_prover_can_lock_user_funds_by_supplying_non-reduced_Y_values_to_G1BigIntToSignFlag/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/succinctlabs/telepathy-circuits/veridise_arrayxor_is_under_constrained/zkbugs_compile.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/veridise_arrayxor_is_under_constrained/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/succinctlabs/telepathy-circuits/veridise_arrayxor_is_under_constrained/zkbugs_compile_setup.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/veridise_arrayxor_is_under_constrained/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/succinctlabs/telepathy-circuits/veridise_arrayxor_is_under_constrained/zkbugs_vars.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/veridise_arrayxor_is_under_constrained/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/succinctlabs/telepathy-circuits/veridise_template_CoreVerifyPubkeyG1_does_not_perform_input_validation_simplified/zkbugs_compile.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/veridise_template_CoreVerifyPubkeyG1_does_not_perform_input_validation_simplified/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/succinctlabs/telepathy-circuits/veridise_template_CoreVerifyPubkeyG1_does_not_perform_input_validation_simplified/zkbugs_compile_setup.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/veridise_template_CoreVerifyPubkeyG1_does_not_perform_input_validation_simplified/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/succinctlabs/telepathy-circuits/veridise_template_CoreVerifyPubkeyG1_does_not_perform_input_validation_simplified/zkbugs_vars.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/veridise_template_CoreVerifyPubkeyG1_does_not_perform_input_validation_simplified/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/succinctlabs/telepathy-circuits/veridise_zero_padding_for_sha256_in_ExpandMessageXMD_is_vulnerable_to_an_overflow/zkbugs_compile.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/veridise_zero_padding_for_sha256_in_ExpandMessageXMD_is_vulnerable_to_an_overflow/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/succinctlabs/telepathy-circuits/veridise_zero_padding_for_sha256_in_ExpandMessageXMD_is_vulnerable_to_an_overflow/zkbugs_compile_setup.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/veridise_zero_padding_for_sha256_in_ExpandMessageXMD_is_vulnerable_to_an_overflow/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/succinctlabs/telepathy-circuits/veridise_zero_padding_for_sha256_in_ExpandMessageXMD_is_vulnerable_to_an_overflow/zkbugs_vars.sh
+++ b/dataset/circom/succinctlabs/telepathy-circuits/veridise_zero_padding_for_sha256_in_ExpandMessageXMD_is_vulnerable_to_an_overflow/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/tangle-network/protocol-solidity/veridise_incorrect_initialization_in_membership_circuits/zkbugs_compile.sh
+++ b/dataset/circom/tangle-network/protocol-solidity/veridise_incorrect_initialization_in_membership_circuits/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/tangle-network/protocol-solidity/veridise_incorrect_initialization_in_membership_circuits/zkbugs_compile_setup.sh
+++ b/dataset/circom/tangle-network/protocol-solidity/veridise_incorrect_initialization_in_membership_circuits/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/tangle-network/protocol-solidity/veridise_incorrect_initialization_in_membership_circuits/zkbugs_vars.sh
+++ b/dataset/circom/tangle-network/protocol-solidity/veridise_incorrect_initialization_in_membership_circuits/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/zkopru-network/zkopru/leastauthority_Circuit_Does_Not_Check_the_ERC_20_Sum_Correctly_/zkbugs_compile.sh
+++ b/dataset/circom/zkopru-network/zkopru/leastauthority_Circuit_Does_Not_Check_the_ERC_20_Sum_Correctly_/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/zkopru-network/zkopru/leastauthority_Circuit_Does_Not_Check_the_ERC_20_Sum_Correctly_/zkbugs_compile_setup.sh
+++ b/dataset/circom/zkopru-network/zkopru/leastauthority_Circuit_Does_Not_Check_the_ERC_20_Sum_Correctly_/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/zkopru-network/zkopru/leastauthority_Circuit_Does_Not_Check_the_ERC_20_Sum_Correctly_/zkbugs_vars.sh
+++ b/dataset/circom/zkopru-network/zkopru/leastauthority_Circuit_Does_Not_Check_the_ERC_20_Sum_Correctly_/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/dataset/circom/zkopru-network/zkopru/leastauthority_previously_correct_ownership_proof_disabled_via_code_changes/zkbugs_compile.sh
+++ b/dataset/circom/zkopru-network/zkopru/leastauthority_previously_correct_ownership_proof_disabled_via_code_changes/zkbugs_compile.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"

--- a/dataset/circom/zkopru-network/zkopru/leastauthority_previously_correct_ownership_proof_disabled_via_code_changes/zkbugs_compile_setup.sh
+++ b/dataset/circom/zkopru-network/zkopru/leastauthority_previously_correct_ownership_proof_disabled_via_code_changes/zkbugs_compile_setup.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v

--- a/dataset/circom/zkopru-network/zkopru/leastauthority_previously_correct_ownership_proof_disabled_via_code_changes/zkbugs_vars.sh
+++ b/dataset/circom/zkopru-network/zkopru/leastauthority_previously_correct_ownership_proof_disabled_via_code_changes/zkbugs_vars.sh
@@ -24,6 +24,8 @@ fi
 PTAU_FILE="$ROOT_PATH/misc/circom/$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "$CODEBASE_PATH" -l "$CIRCOMLIB_PATH")
+
 # Derive TARGET from the entrypoint filename
 TARGET=$(basename "$CIRCOM_CIRCUIT" .circom)
 R1CS="$TARGET.r1cs"

--- a/scripts/print_bug_vars.sh
+++ b/scripts/print_bug_vars.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# Print a JSON description of a circom bug's compile contract.
+#
+# Usage: print_bug_vars.sh <bug_dir> [--mode direct|original]
+#
+# Sources the bug's zkbugs_vars.sh under the requested ZKBUGS_MODE and emits a
+# JSON object on stdout with absolute paths for circuit, input, ptau, codebase
+# and a flat link_flags list matching the CIRCOM_LINK_FLAGS bash array.
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'USAGE'
+Usage: print_bug_vars.sh <bug_dir> [--mode direct|original]
+
+Prints a JSON description of a circom bug's compile contract.
+Default mode is "direct".
+USAGE
+}
+
+MODE="direct"
+BUG_DIR_ARG=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --mode)
+            if [ $# -lt 2 ]; then
+                echo "error: --mode requires an argument" >&2
+                exit 2
+            fi
+            MODE="$2"
+            shift 2
+            ;;
+        -h|--help) usage; exit 0 ;;
+        --) shift; break ;;
+        -*)
+            echo "error: unknown flag: $1" >&2
+            usage
+            exit 2
+            ;;
+        *)
+            if [ -z "$BUG_DIR_ARG" ]; then
+                BUG_DIR_ARG="$1"
+                shift
+            else
+                echo "error: unexpected argument: $1" >&2
+                exit 2
+            fi
+            ;;
+    esac
+done
+
+if [ "$MODE" != "direct" ] && [ "$MODE" != "original" ]; then
+    echo "error: --mode must be 'direct' or 'original' (got '$MODE')" >&2
+    exit 2
+fi
+
+if [ -z "$BUG_DIR_ARG" ]; then
+    usage
+    exit 2
+fi
+
+if [ ! -d "$BUG_DIR_ARG" ]; then
+    echo "error: bug_dir not found: $BUG_DIR_ARG" >&2
+    exit 1
+fi
+
+BUG_DIR_ABS=$(cd "$BUG_DIR_ARG" && pwd)
+VARS_FILE="$BUG_DIR_ABS/zkbugs_vars.sh"
+
+if [ ! -f "$VARS_FILE" ]; then
+    echo "error: zkbugs_vars.sh missing in $BUG_DIR_ABS" >&2
+    exit 1
+fi
+
+# Python body used by the inner bash to serialize the final JSON. Exported so
+# the inner bash inherits it and can invoke python3 -c "$_PRINT_BUG_VARS_PY".
+export _PRINT_BUG_VARS_PY='
+import json, os, sys
+out = {
+    "mode": os.environ["_OUT_MODE"],
+    "circuit": os.environ["_OUT_CIRCUIT"],
+    "link_flags": sys.argv[1:],
+    "input": os.environ["_OUT_INPUT"],
+    "ptau": os.environ["_OUT_PTAU"],
+    "target": os.environ["_OUT_TARGET"],
+    "codebase": os.environ["_OUT_CODEBASE"],
+    "codebase_exists": os.environ["_OUT_CODEBASE_EXISTS"] == "true",
+}
+print(json.dumps(out, indent=2))
+'
+
+# Run zkbugs_vars.sh inside a sub-bash where $0 is set to the absolute path of
+# the vars file. zkbugs_vars.sh derives BUG_DIR from realpath "$0", so setting
+# $0 correctly makes the sourced script work regardless of the caller's cwd.
+cd "$BUG_DIR_ABS"
+ZKBUGS_MODE="$MODE" bash -c '
+    set -u
+    # shellcheck disable=SC1091
+    source ./zkbugs_vars.sh
+    if ! declare -p CIRCOM_LINK_FLAGS >/dev/null 2>&1; then
+        echo "error: CIRCOM_LINK_FLAGS not defined by zkbugs_vars.sh" >&2
+        exit 3
+    fi
+    if [[ "${INPUTJSON:-}" = /* ]]; then
+        input_abs="$INPUTJSON"
+    else
+        input_abs="$BUG_DIR/${INPUTJSON:-}"
+    fi
+    target="${TARGET:-$(basename "$CIRCOM_CIRCUIT" .circom)}"
+    codebase_exists=false
+    [ -d "$CODEBASE_PATH" ] && codebase_exists=true
+    export _OUT_MODE="$ZKBUGS_MODE"
+    export _OUT_CIRCUIT="$CIRCOM_CIRCUIT"
+    export _OUT_INPUT="$input_abs"
+    export _OUT_PTAU="$PTAU_FILE"
+    export _OUT_TARGET="$target"
+    export _OUT_CODEBASE="$CODEBASE_PATH"
+    export _OUT_CODEBASE_EXISTS="$codebase_exists"
+    python3 -c "$_PRINT_BUG_VARS_PY" "${CIRCOM_LINK_FLAGS[@]}"
+' "$VARS_FILE"

--- a/scripts/test_print_vars.sh
+++ b/scripts/test_print_vars.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Validate scripts/print_bug_vars.sh output across every circom bug.
+#
+# For each bug dir under dataset/circom/*/*/*/ and each mode in {direct, original}:
+#   - run print_bug_vars.sh
+#   - require the output parses as JSON
+#   - require the "circuit" file exists on disk
+#   - require every path following a "-l" token in "link_flags" exists on disk
+#
+# Assumes scripts/download_sources.sh has populated dataset/codebases/...
+#
+# Usage: test_print_vars.sh
+
+set -uo pipefail
+
+ROOT=$(dirname "$(dirname "$(realpath "$0")")")
+cd "$ROOT"
+
+PRINT_VARS="$ROOT/scripts/print_bug_vars.sh"
+if [ ! -x "$PRINT_VARS" ]; then
+    echo "error: $PRINT_VARS not executable" >&2
+    exit 1
+fi
+
+pass=0
+fail=0
+skip=0
+total=0
+FAILED_BUGS=()
+SKIPPED_BUGS=()
+
+for d in dataset/circom/*/*/*/; do
+    [ -f "$d/zkbugs_vars.sh" ] || continue
+    echo "$d" | grep -q "dependencies" && continue
+
+    for mode in direct original; do
+        total=$((total + 1))
+        out=$(bash "$PRINT_VARS" "$d" --mode "$mode" 2>&1)
+        rc=$?
+        if [ $rc -ne 0 ]; then
+            echo "FAIL [$mode] $d: print_bug_vars.sh exited $rc"
+            echo "$out" | sed 's/^/    /'
+            fail=$((fail + 1))
+            FAILED_BUGS+=("$mode:$d")
+            continue
+        fi
+
+        # Validate with python: parse JSON, check circuit + every -l path
+        # exists. Exits 0 pass, 1 fail, 2 skip (codebase not downloaded).
+        err=$(printf '%s' "$out" | python3 -c '
+import json, os, sys
+data = sys.stdin.read()
+try:
+    obj = json.loads(data)
+except Exception as e:
+    print(f"json parse error: {e}"); sys.exit(1)
+
+if not obj.get("codebase_exists", False):
+    print("codebase not downloaded: " + str(obj.get("codebase")))
+    sys.exit(2)
+
+missing = []
+circuit = obj.get("circuit")
+if not circuit or not os.path.isfile(circuit):
+    missing.append(f"circuit missing: {circuit!r}")
+
+flags = obj.get("link_flags", [])
+i = 0
+while i < len(flags):
+    tok = flags[i]
+    if tok == "-l":
+        if i + 1 >= len(flags):
+            missing.append("link_flags ended with dangling -l")
+            break
+        p = flags[i + 1]
+        if not os.path.isdir(p):
+            missing.append(f"link path missing: {p}")
+        i += 2
+    else:
+        missing.append(f"unexpected token in link_flags: {tok!r}")
+        i += 1
+
+if missing:
+    for m in missing:
+        print(m)
+    sys.exit(1)
+' 2>&1)
+        rc=$?
+        if [ $rc -eq 2 ]; then
+            echo "SKIP [$mode] $d (codebase not downloaded)"
+            skip=$((skip + 1))
+            SKIPPED_BUGS+=("$mode:$d")
+        elif [ $rc -ne 0 ]; then
+            echo "FAIL [$mode] $d"
+            printf '%s\n' "$err" | sed 's/^/    /'
+            fail=$((fail + 1))
+            FAILED_BUGS+=("$mode:$d")
+        else
+            pass=$((pass + 1))
+        fi
+    done
+done
+
+echo ""
+echo "=== Results ==="
+echo "Total checks: $total"
+echo "Passed:       $pass"
+echo "Skipped:      $skip"
+echo "Failed:       $fail"
+
+if [ $skip -gt 0 ]; then
+    echo ""
+    echo "Skipped entries (codebase not downloaded):"
+    for s in "${SKIPPED_BUGS[@]}"; do
+        echo "  $s"
+    done
+fi
+
+if [ $fail -gt 0 ]; then
+    echo ""
+    echo "Failed entries:"
+    for f in "${FAILED_BUGS[@]}"; do
+        echo "  $f"
+    done
+    exit 1
+fi

--- a/scripts/zkbugs_new_bug.sh
+++ b/scripts/zkbugs_new_bug.sh
@@ -118,6 +118,8 @@ fi
 PTAU_FILE="\$ROOT_PATH/misc/circom/\$PTAU_TARGET"
 PTAU_FINAL="final.ptau"
 
+CIRCOM_LINK_FLAGS=(-l "\$CODEBASE_PATH" -l "\$CIRCOMLIB_PATH")
+
 TARGET=\$(basename "\$CIRCOM_CIRCUIT" .circom)
 R1CS="\$TARGET.r1cs"
 ZKEY_INIT=\${TARGET}_0000.zkey
@@ -141,7 +143,7 @@ if ! command -v circom &> /dev/null; then
 fi
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Compilation successful."
 echo "  R1CS:  $R1CS"
@@ -170,7 +172,7 @@ else
 fi
 
 echo "Compiling the target circuit: $CIRCOM_CIRCUIT"
-circom $CIRCOM_CIRCUIT --O0 --r1cs --wasm --sym -l $CODEBASE_PATH -l $CIRCOMLIB_PATH
+circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
 
 echo "Phase 2 of the ceremony producing zkey and verification key: ${ZKEY_FINAL}"
 snarkjs powersoftau prepare phase2 ${PTAU_FILE} ${PTAU_FINAL} -v


### PR DESCRIPTION
## Summary
- Every circom bug now exposes a machine-readable compile contract via `CIRCOM_LINK_FLAGS` (bash array) in `zkbugs_vars.sh`. `zkbugs_compile.sh` and `zkbugs_compile_setup.sh` collapse to one uniform circom line.
- New `scripts/print_bug_vars.sh` serializes the contract as JSON for any bug in either mode. New `scripts/test_print_vars.sh` validates it across all 39 bugs in both modes.
- `scripts/zkbugs_new_bug.sh` scaffold updated so new bugs conform.

## Bugs touched
All 39 circom bugs under `dataset/circom/*/*/*/`. Three `-l` shapes today:
- 30 bugs: `-l \$CODEBASE_PATH -l \$CIRCOMLIB_PATH`
- 1 (MACI): `-l \$CODEBASE_PATH -l \$CODEBASE_PATH/circuits/node_modules`
- 8 (selfxyz): `-l \$CODEBASE_PATH -l \$CIRCOMLIB_PATH -l \$CIRCOMLIB_PATH/circomlib/circuits -l \$CODEBASE_PATH/circuits/node_modules`

Flags are identical across `ZKBUGS_MODE=direct` and `ZKBUGS_MODE=original` for every bug — no mode-branch was needed.

## CIRCOM_LINK_FLAGS contract
Bash array in `zkbugs_vars.sh`; every element is either the literal `-l` or a path. Expanded at the call site with `"${CIRCOM_LINK_FLAGS[@]}"` to preserve paths with spaces. Defined after `PTAU_FILE`/`PTAU_FINAL` and before `TARGET` derivation. The uniform compile line is:

```
circom "$CIRCOM_CIRCUIT" --O0 --r1cs --wasm --sym "${CIRCOM_LINK_FLAGS[@]}"
```

## print_bug_vars.sh interface
```
Usage: print_bug_vars.sh <bug_dir> [--mode direct|original]
```
Default mode is `direct`. Accepts absolute or relative `<bug_dir>`, works from any cwd. No new dependencies — bash + python3 (already used in `scripts/`). Emits a single JSON object on stdout:

```json
{
  "mode": "direct",
  "circuit": "/abs/path/to/circuit.circom",
  "link_flags": ["-l", "/abs/codebase", "-l", "/abs/circomlib"],
  "input": "/abs/path/direct_input.json",
  "ptau": "/abs/path/bn128_pot12_0001.ptau",
  "target": "circuit",
  "codebase": "/abs/path/codebases/.../<commit>",
  "codebase_exists": true
}
```

All paths absolute. Exits non-zero with a clear message if `zkbugs_vars.sh` is missing, if `--mode` is invalid, or if a bug's `zkbugs_vars.sh` fails to define `CIRCOM_LINK_FLAGS`.

## zkhydra integration
zkhydra runs `scripts/print_bug_vars.sh <bug_dir> --mode <mode>`, parses the JSON, and has everything needed to drive any bug: the absolute entrypoint (`circuit`), the exact link flags to splat into its own circom invocation (`link_flags`), the witness input file (`input`), the ptau file (`ptau`), and the expected target basename (`target`). No per-bug parsing of `zkbugs_compile.sh`, no path math, no dependency on the repo layout beyond this stable field set.

## Test plan
- [x] `bash scripts/test_all_circom.sh --compile-only --mode both` → 39/39 COMPILE_OK (78 checks)
- [x] `bash scripts/test_print_vars.sh` → 72 pass, 6 skip (reclaim codebase upstream-unreachable), 0 fail
- [x] Spot-check JSON output for circomlib (2-flag), semaphore, zkopru, MACI (unique 2-flag), and selfxyz (4-flag) bugs matches the pre-refactor inline flags exactly