### PR TITLE
reproduce: iden3 MiMC Hash unconstrained output bug (#12)

### DIFF
--- a/dataset/circom/iden3/circomlib/kobi_gurkan_mimc_hash_assigned_but_not_constrained/zkbugs_config.json
+++ b/dataset/circom/iden3/circomlib/kobi_gurkan_mimc_hash_assigned_but_not_constrained/zkbugs_config.json
@@ -9,7 +9,7 @@
         "Vulnerability": "Under-Constrained",
         "Impact": "Soundness",
         "Root Cause": "Assigned but Unconstrained",
-        "Reproduced": false,
+        "Reproduced": true,
         "Codebase": "dataset/codebases/circom/iden3/circomlib/324b8bf8cc4a80357354752deb6c2ae5be22e5f5",
         "Direct Entrypoint": "circuit.circom",
         "Location": {


### PR DESCRIPTION
Description:
I have successfully reproduced the MiMC Hash soundness bug (#12).

Root Cause:
The outs[0] signal in mimcsponge.circom was assigned using the <-- operator but lacked a corresponding <== constraint. This allows a prover to generate a valid proof for an arbitrary (fake) hash value.  

Reproduction Steps:

1.)Ran ./zkbugs_setup.sh and linked the codebase.

2.)Modified direct_input.json to include a fake output: "outs": ["123456789"].

3.)Ran ZKBUGS_MODE=direct ./zkbugs_positive_test.sh.

4.)Verified that snarkjs returned OK! despite the incorrect hash.
<img width="478" height="147" alt="Screenshot 2026-05-03 094607" src="https://github.com/user-attachments/assets/2baec532-ec29-4e57-8e9a-a5b1c7ecadbe" />
